### PR TITLE
Fix windowrule → windowrulev2 corruption on save

### DIFF
--- a/hyprmod/core/config.py
+++ b/hyprmod/core/config.py
@@ -48,11 +48,10 @@ KEYWORD_ENV = "env"
 KEYWORD_EXEC = "exec"
 KEYWORD_EXEC_ONCE = "exec-once"
 # ``windowrule`` is the Hyprland 0.53+ canonical name; ``windowrulev2`` is
-# the 0.48–0.52 spelling for the same syntax. We accept both on read; the
-# Window Rules page writes ``windowrulev2`` (the form well-supported across
-# the long tail of installed versions). When ``hyprland_config.migrate()``
-# learns the v2 → v3 rename, the auto-migration on save will rewrite our
-# output without UI changes.
+# the 0.48–0.52 spelling for the same syntax. We accept both on read.
+# Output is always v3 ``windowrule`` — migration is skipped for window
+# rules on save because ``hyprland_config.migrate()`` incorrectly
+# converts v3 windowrule → windowrulev2.
 KEYWORD_WINDOWRULE = "windowrule"
 KEYWORD_WINDOWRULEV2 = "windowrulev2"
 
@@ -238,11 +237,18 @@ def build_content(
     # Autostart goes last: ``exec`` re-runs on every reload, so any
     # config later in the file that affects the exec'd process (env
     # vars, monitor layout, …) is already in effect by the time the
-    # commands run.
+    # exec'd commands run.
     if exec_lines:
         _append_section(lines, "Autostart", exec_lines)
 
-    return _auto_migrate_content("".join(lines))
+    content = "".join(lines)
+    if window_rule_lines:
+        non_rule_content = content[: content.rfind("# Window rules\n")].rstrip("\n")
+        if non_rule_content:
+            migrated = _auto_migrate_content(non_rule_content)
+            rule_section_start = content.find("# Window rules\n")
+            return migrated + "\n" + content[rule_section_start:]
+    return _auto_migrate_content(content)
 
 
 def write_all(

--- a/hyprmod/pages/window_rules.py
+++ b/hyprmod/pages/window_rules.py
@@ -142,8 +142,7 @@ class WindowRulesPage(SectionPage):
             _, saved_sections = config.read_all_sections()
         # Read both ``windowrule`` and ``windowrulev2`` so users with
         # hand-rolled lines in either form see them in the UI. The
-        # write path emits ``windowrulev2`` for new rules but preserves
-        # the original keyword on edit (see WindowRuleEditDialog).
+        # write path emits ``windowrule`` (v3) for all rules.
         raw_lines = config.collect_section(saved_sections, *WINDOW_RULE_KEYWORDS)
         items = parse_window_rule_lines(raw_lines)
         self._owned = SavedList(items, key=lambda r: r.to_line())


### PR DESCRIPTION
hyprland_config.migrate() incorrectly treats the v3 'windowrule' keyword as deprecated v1 and converts it to 'windowrulev2', mangling effects like 'float on' into 'title:float on'.

Skip migration for window rule lines in build_content() since hyprmod generates them in the correct v3 format. Other deprecated syntax still gets migrated normally.

Also fix outdated comments that said the write path emits windowrulev2.