### PR TITLE
Add advanced HDR monitor controls

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Lua config support — read and edit `hyprland.lua` directly, with live preview against Hyprland 0.55+'s Lua runtime
 - "Migrate to Lua…" wizard and main-window banner (Hyprland 0.55+) — converts your active `hyprland.conf` to `hyprland.lua`, rewrites the entrypoint include, and is dismissible
 - Per-monitor "Identify by description" toggle — emits `monitor=desc:…` instead of `monitor=DP-1, …` so the saved configuration follows the physical monitor across port changes (#26)
-- Per-monitor HDR controls — expanded Color Management presets (Auto/sRGB/Adobe/Wide/EDID/HDR/HDR EDID) and new SDR Brightness / SDR Saturation options that appear only when an HDR preset is active (#29)
+- Per-monitor HDR controls — expanded Color Management presets (Auto/sRGB/Adobe/Wide/EDID/HDR/HDR EDID), SDR Brightness/Saturation sliders, advanced SDR/HDR luminance sliders, lock-step luminance controls, and safe defaults for first-time HDR setup (#29)
 - Workspaces page — manage `workspace` rules with live preview and live IPC apply (#31)
 - Deprecation assistant — detect and migrate deprecated Hyprland syntax with explicit user confirmation and timestamped backups
 - Convenience installer (`install.sh`) and `hyprmod --install` / `--uninstall` flags — `pipx`/`uv tool` installs now register a desktop launcher entry and icon under `$XDG_DATA_HOME`, with first-launch self-registration as a fallback

--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ Huge thanks to the creators below — without you, HyprMod would reach far fewer
 
 - **Lua config support** — migrate and edit `hyprland.lua` directly (Hyprland 0.55+)
 - Bezier curve editor with live animation preview
-- Monitor layout editor with VRR, HDR, and 10-bit detection
+- Monitor layout editor with VRR, 10-bit detection, and advanced HDR controls with safe defaults
 - Keybind editor with interactive key capture, including mouse-drag (`bindm`) binds
 - Window rules, layer rules, and workspace rules editors with live preview
 - Autostart (`exec` / `exec-once`) and environment variable management

--- a/hyprmod/data/icons/hicolor/scalable/actions/changes-allow-symbolic.svg
+++ b/hyprmod/data/icons/hicolor/scalable/actions/changes-allow-symbolic.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 16 16">
+ <rect width="14" height="10" x="1" y="6" rx="2" style="fill:#bebebe;opacity:1;fill-opacity:1;stroke:none;fill-rule:nonzero"/>
+ <path d="m 10 0 c -0.82 0 -1.64 0.164 -2.396 0.49 c -1.512 0.653 -2.604 1.965 -2.604 3.51 l 0 3 l 2 0 l 0 -3 c 0 -0.594 0.433 -1.258 1.396 -1.674 c 0.963 -0.416 2.244 -0.416 3.207 0 c 0.963 0.416 1.396 1.08 1.396 1.674 l 0 1.25 l 2 0 l 0 -1.25 c 0 -1.545 -1.091 -2.857 -2.604 -3.51 c -0.756 -0.327 -1.576 -0.49 -2.396 -0.49 z" mix-blend-mode="normal" isolation="auto" white-space="normal" solid-opacity="1" solid-color="#000000" style="visibility:visible;shape-rendering:auto;color-interpolation-filters:linearRGB;fill:#bebebe;opacity:1;image-rendering:auto;fill-opacity:1;stroke:none;display:inline;color:#000;fill-rule:nonzero;color-rendering:auto;color-interpolation:sRGB"/>
+</svg>

--- a/hyprmod/pages/monitors/card.py
+++ b/hyprmod/pages/monitors/card.py
@@ -1,5 +1,7 @@
 """Editable card widget for a single monitor."""
 
+from dataclasses import dataclass
+
 from gi.repository import Adw, Gtk
 from hyprland_monitors.monitors import (
     TRANSFORMS,
@@ -22,10 +24,11 @@ VRR_VALUES = [None, "1", "2", "3"]
 CM_MODES = ["Auto", "sRGB", "Adobe", "Wide", "EDID", "HDR", "HDR (EDID)"]
 CM_VALUES = [None, "srgb", "adobe", "wide", "edid", "hdr", "hdredid"]
 
-# Hyprland applies sdrbrightness/sdrsaturation only when an HDR preset is active.
+# Hyprland applies SDR/HDR luminance controls only when HDR output is active.
 _HDR_CM_VALUES = frozenset({"hdr", "hdredid"})
 
-# UI range for the SDR brightness/saturation spinners.
+# UI range for the SDR brightness/saturation sliders.
+SLIDER_VALUE_WIDTH_CHARS = 7
 SDR_VALUE_MIN = 0.0
 SDR_VALUE_MAX = 2.0
 SDR_VALUE_STEP = 0.05
@@ -33,27 +36,167 @@ SDR_VALUE_DIGITS = 2
 SDR_VALUE_DEFAULT = 1.0
 
 
+@dataclass(frozen=True)
+class _HdrSliderSpec:
+    field: str
+    title: str
+    subtitle: str
+    default: float
+    minimum: float
+    maximum: float
+    step: float
+    page: float
+    digits: int
+    display_digits: int | None = None
+    auto_default: bool = False
+
+
+HDR_SLIDER_SPECS = (
+    _HdrSliderSpec(
+        "sdr_brightness",
+        "SDR Brightness",
+        "Brightness for SDR content in HDR mode",
+        SDR_VALUE_DEFAULT,
+        SDR_VALUE_MIN,
+        SDR_VALUE_MAX,
+        SDR_VALUE_STEP,
+        SDR_VALUE_STEP * 4,
+        SDR_VALUE_DIGITS,
+        2,
+    ),
+    _HdrSliderSpec(
+        "sdr_saturation",
+        "SDR Saturation",
+        "Saturation for SDR content in HDR mode",
+        SDR_VALUE_DEFAULT,
+        SDR_VALUE_MIN,
+        SDR_VALUE_MAX,
+        SDR_VALUE_STEP,
+        SDR_VALUE_STEP * 4,
+        SDR_VALUE_DIGITS,
+        2,
+    ),
+    _HdrSliderSpec(
+        "sdr_min_luminance",
+        "SDR Min Luminance",
+        "Minimum luminance for SDR to HDR mapping",
+        0.0,
+        0.0,
+        1.0,
+        0.05,
+        0.1,
+        2,
+    ),
+    _HdrSliderSpec(
+        "sdr_max_luminance",
+        "SDR Max Luminance",
+        "Maximum luminance for SDR content",
+        800.0,
+        0.0,
+        2000.0,
+        10.0,
+        100.0,
+        0,
+    ),
+    _HdrSliderSpec(
+        "min_luminance",
+        "HDR Min Luminance",
+        "Minimum luminance for HDR output",
+        0.0,
+        0.0,
+        1.0,
+        0.05,
+        0.1,
+        2,
+    ),
+    _HdrSliderSpec(
+        "max_luminance",
+        "HDR Max Luminance",
+        "Maximum luminance for HDR output",
+        800.0,
+        0.0,
+        2000.0,
+        10.0,
+        100.0,
+        0,
+    ),
+    _HdrSliderSpec(
+        "max_avg_luminance",
+        "Max Avg Luminance",
+        "Monitor maximum average luminance",
+        500.0,
+        0.0,
+        2000.0,
+        10.0,
+        100.0,
+        0,
+        None,
+        True,
+    ),
+)
+HDR_SLIDER_FIELDS = tuple(spec.field for spec in HDR_SLIDER_SPECS)
+HDR_SLIDER_SPEC_BY_FIELD = {spec.field: spec for spec in HDR_SLIDER_SPECS}
+HDR_RESET_FIELDS = HDR_SLIDER_FIELDS
+LOCKED_LUMINANCE_PAIRS = {
+    "sdr_min_luminance": "min_luminance",
+    "min_luminance": "sdr_min_luminance",
+    "sdr_max_luminance": "max_luminance",
+    "max_luminance": "sdr_max_luminance",
+}
+LOCKED_LUMINANCE_FIELD_SET = frozenset(LOCKED_LUMINANCE_PAIRS)
+HDR_LOCKED_ICON = "changes-prevent-symbolic"
+HDR_UNLOCKED_ICON = "changes-allow-symbolic"
+
+
 def _parse_sdr(value: str | None) -> float:
-    """Parse a stored sdr_brightness/sdr_saturation string into the spinner's float."""
+    """Parse a stored sdr_brightness/sdr_saturation string into a slider value."""
+    return _parse_hdr_value(value, SDR_VALUE_DEFAULT)
+
+
+def _parse_hdr_value(value: str | None, default: float) -> float:
+    """Parse a stored HDR numeric value for a slider."""
     if value is None:
-        return SDR_VALUE_DEFAULT
+        return default
     try:
         return float(value)
     except ValueError:
-        return SDR_VALUE_DEFAULT
+        return default
 
 
 def _format_sdr(value: float) -> str | None:
-    """Format a spinner value back into config-line form, or None at the default.
+    """Format a slider value back into config-line form, or None at the default.
 
     Keeps at least one integer digit so ``0`` renders as ``"0"`` rather than ``""``.
     """
-    # Epsilon handles FP jitter from the spinner; the user picks exact 1.0 to reset.
-    if abs(value - SDR_VALUE_DEFAULT) < 1e-3:
+    return _format_hdr_value(value, SDR_VALUE_DEFAULT, SDR_VALUE_DIGITS)
+
+
+def _format_hdr_value(value: float, default: float, digits: int) -> str | None:
+    """Format a slider value back into config-line form, or None at the default."""
+    # Epsilon handles FP jitter from the slider; picking the exact default resets.
+    if abs(value - default) < 1e-3:
         return None
-    int_part, _, frac = f"{value:.2f}".partition(".")
+    int_part, _, frac = f"{value:.{digits}f}".partition(".")
     frac = frac.rstrip("0")
     return f"{int_part}.{frac}" if frac else int_part
+
+
+def _format_hdr_raw_value(value: float, digits: int) -> str:
+    int_part, _, frac = f"{value:.{digits}f}".partition(".")
+    frac = frac.rstrip("0")
+    return f"{int_part}.{frac}" if frac else int_part
+
+
+def _format_hdr_display_value(value: float, spec: _HdrSliderSpec) -> str:
+    """Format the visible slider value label."""
+    if spec.auto_default and abs(value - spec.default) < 1e-3:
+        return "Auto"
+    digits = spec.display_digits if spec.display_digits is not None else spec.digits
+    return f"{value:.{digits}f}"
+
+
+def _monitor_extra(mon: MonitorState, field: str) -> str | None:
+    return getattr(mon, field, None)
 
 
 class MonitorCard(Gtk.Box):
@@ -311,10 +454,8 @@ class MonitorCard(Gtk.Box):
             self._on_cm_changed,
             lambda: self._discard_fields("color_management"),
         )
-        # SDR brightness/saturation only affect SDR content while an HDR preset is
-        # active; we build a single row with two inline spinboxes (mirroring the
-        # Position row) and toggle visibility based on the current cm value.
-        self._sdr_row = self._build_sdr_row(monitor)
+        self._hdr_reset_row = self._build_hdr_reset_row()
+        self._hdr_slider_rows = self._build_hdr_slider_rows(monitor)
         self._bitdepth_row = self._build_extra_combo(
             "ten_bit",
             "Bit Depth",
@@ -335,10 +476,16 @@ class MonitorCard(Gtk.Box):
             self._on_vrr_changed,
             lambda: self._discard_fields("vrr"),
         )
-        for row in (self._cm_row, self._sdr_row, self._bitdepth_row, self._vrr_row):
+        for row in (
+            self._cm_row,
+            self._hdr_reset_row,
+            *self._hdr_slider_rows,
+            self._bitdepth_row,
+            self._vrr_row,
+        ):
             if row is not None:
                 self._advanced_expander.add_row(row)
-        self._refresh_sdr_visibility()
+        self._refresh_hdr_slider_visibility()
 
         self.append(advanced_group)
 
@@ -359,10 +506,11 @@ class MonitorCard(Gtk.Box):
             self._pos_row,
             self._mirror_row,
             self._cm_row,
-            self._sdr_row,
+            self._hdr_reset_row,
             self._bitdepth_row,
             self._vrr_row,
             self._identify_row,
+            *self._hdr_slider_rows,
         ):
             if row is not None:
                 self._searchable.append((row.get_title(), row.get_subtitle() or ""))
@@ -440,51 +588,87 @@ class MonitorCard(Gtk.Box):
         self._attach_row_actions(row, on_discard)
         return row
 
-    def _build_sdr_row(self, monitor: MonitorState) -> Adw.ActionRow | None:
-        """Build a single SDR row with inline brightness/saturation spinboxes."""
+    def _build_hdr_reset_row(self) -> Adw.ActionRow | None:
+        self._hdr_reset_button: Gtk.Button | None = None
         if not self._caps.get("hdr"):
-            self._sdr_brightness = None
-            self._sdr_saturation = None
             return None
 
-        self._sdr_brightness = self._make_sdr_spin(_parse_sdr(monitor.sdr_brightness))
-        self._sdr_saturation = self._make_sdr_spin(_parse_sdr(monitor.sdr_saturation))
-
-        row = Adw.ActionRow(
-            title="SDR",
-            subtitle="Brightness and saturation for SDR content in HDR mode",
-        )
-        for label_text, widget, margin_start, margin_end in [
-            ("Brightness", self._sdr_brightness, 0, 4),
-            ("Saturation", self._sdr_saturation, 12, 4),
-        ]:
-            lbl = Gtk.Label(label=label_text)
-            lbl.add_css_class("dim-label")
-            lbl.set_valign(Gtk.Align.CENTER)
-            lbl.set_margin_start(margin_start)
-            lbl.set_margin_end(margin_end)
-            row.add_suffix(lbl)
-            row.add_suffix(widget)
-
-        self._signals.connect(self._sdr_brightness, "value-changed", self._on_sdr_changed)
-        self._signals.connect(self._sdr_saturation, "value-changed", self._on_sdr_changed)
-        self._attach_row_actions(
-            row, lambda: self._discard_fields("sdr_brightness", "sdr_saturation")
-        )
+        row = Adw.ActionRow(title="Safe Defaults", subtitle="Restore conservative HDR values")
+        self._hdr_reset_button = Gtk.Button(icon_name="edit-undo-symbolic")
+        self._hdr_reset_button.set_valign(Gtk.Align.CENTER)
+        self._hdr_reset_button.set_tooltip_text("Apply safe defaults")
+        self._hdr_reset_button.add_css_class("flat")
+        row.add_suffix(self._hdr_reset_button)
+        self._signals.connect(self._hdr_reset_button, "clicked", self._on_hdr_reset_clicked)
         return row
 
-    def _make_sdr_spin(self, value: float) -> Gtk.SpinButton:
-        return Gtk.SpinButton(
+    def _build_hdr_slider_rows(self, monitor: MonitorState) -> list[Adw.ActionRow]:
+        """Build one slider row for each HDR-related monitor value."""
+        self._hdr_sliders: dict[str, Gtk.Scale] = {}
+        self._hdr_value_labels: dict[str, Gtk.Label] = {}
+        self._hdr_lock_active = False
+        self._hdr_lock_buttons: dict[str, Gtk.ToggleButton] = {}
+        if not self._caps.get("hdr"):
+            return []
+
+        rows: list[Adw.ActionRow] = []
+        for spec in HDR_SLIDER_SPECS:
+            value = _parse_hdr_value(_monitor_extra(monitor, spec.field), spec.default)
+            row = Adw.ActionRow(title=spec.title, subtitle=spec.subtitle)
+            scale = self._make_hdr_slider(spec, value)
+            value_label = Gtk.Label(
+                label=self._format_hdr_label(value, spec),
+                width_chars=SLIDER_VALUE_WIDTH_CHARS,
+                xalign=1,
+            )
+            value_label.add_css_class("dim-label")
+            value_label.set_valign(Gtk.Align.CENTER)
+            lock_button = self._build_hdr_lock_button(spec)
+            if lock_button is not None:
+                row.add_suffix(lock_button)
+            row.add_suffix(scale)
+            row.add_suffix(value_label)
+
+            self._hdr_sliders[spec.field] = scale
+            self._hdr_value_labels[spec.field] = value_label
+            self._signals.connect(scale, "value-changed", self._on_hdr_slider_changed, spec)
+            self._attach_row_actions(row, lambda f=spec.field: self._discard_fields(f))
+            rows.append(row)
+        return rows
+
+    def _build_hdr_lock_button(self, spec: _HdrSliderSpec) -> Gtk.ToggleButton | None:
+        if spec.field not in LOCKED_LUMINANCE_FIELD_SET:
+            return None
+
+        peer = HDR_SLIDER_SPEC_BY_FIELD[LOCKED_LUMINANCE_PAIRS[spec.field]]
+        button = Gtk.ToggleButton()
+        button.set_child(Gtk.Image.new_from_icon_name(HDR_UNLOCKED_ICON))
+        button.set_valign(Gtk.Align.CENTER)
+        button.set_active(self._hdr_lock_active)
+        button.set_tooltip_text(f"Lock {spec.title} with {peer.title}")
+        button.add_css_class("flat")
+        self._hdr_lock_buttons[spec.field] = button
+        self._signals.connect(button, "toggled", self._on_hdr_lock_toggled, spec.field)
+        return button
+
+    def _make_hdr_slider(self, spec: _HdrSliderSpec, value: float) -> Gtk.Scale:
+        scale = Gtk.Scale(
+            orientation=Gtk.Orientation.HORIZONTAL,
             adjustment=Gtk.Adjustment(
                 value=value,
-                lower=SDR_VALUE_MIN,
-                upper=SDR_VALUE_MAX,
-                step_increment=SDR_VALUE_STEP,
-                page_increment=SDR_VALUE_STEP * 4,
+                lower=spec.minimum,
+                upper=spec.maximum,
+                step_increment=spec.step,
+                page_increment=spec.page,
             ),
-            digits=SDR_VALUE_DIGITS,
-            valign=Gtk.Align.CENTER,
         )
+        scale.set_digits(spec.digits)
+        scale.set_draw_value(False)
+        scale.set_size_request(220, -1)
+        scale.set_valign(Gtk.Align.CENTER)
+        if spec.field in {"sdr_brightness", "sdr_saturation"}:
+            scale.add_mark(SDR_VALUE_DEFAULT, Gtk.PositionType.BOTTOM, None)
+        return scale
 
     def _is_hdr_cm_active(self) -> bool:
         """Whether the current cm preset is one that makes sdr* values effective."""
@@ -495,9 +679,15 @@ class MonitorCard(Gtk.Box):
             return False
         return CM_VALUES[idx] in _HDR_CM_VALUES
 
-    def _refresh_sdr_visibility(self):
-        if self._sdr_row is not None:
-            self._sdr_row.set_visible(self._is_hdr_cm_active())
+    def _refresh_hdr_slider_visibility(self):
+        visible = self._is_hdr_cm_active()
+        if self._hdr_reset_row is not None:
+            self._hdr_reset_row.set_visible(visible)
+        for row in self._hdr_slider_rows:
+            row.set_visible(visible)
+
+    def _format_hdr_label(self, value: float, spec: _HdrSliderSpec) -> str:
+        return _format_hdr_display_value(value, spec)
 
     def _attach_row_actions(self, row: Adw.ActionRow | Adw.ComboRow, discard_handler):
         """Attach a RowActions strip (discard only, no per-row remove)."""
@@ -547,11 +737,16 @@ class MonitorCard(Gtk.Box):
             if self._cm_row:
                 c = mon.color_management
                 self._cm_row.set_selected(CM_VALUES.index(c) if c in CM_VALUES else 0)
-            if self._sdr_brightness is not None:
-                self._sdr_brightness.set_value(_parse_sdr(mon.sdr_brightness))
-            if self._sdr_saturation is not None:
-                self._sdr_saturation.set_value(_parse_sdr(mon.sdr_saturation))
-            self._refresh_sdr_visibility()
+            for spec in HDR_SLIDER_SPECS:
+                slider = self._hdr_sliders.get(spec.field)
+                if slider is None:
+                    continue
+                value = _parse_hdr_value(_monitor_extra(mon, spec.field), spec.default)
+                slider.set_value(value)
+                label = self._hdr_value_labels.get(spec.field)
+                if label is not None:
+                    label.set_label(self._format_hdr_label(value, spec))
+            self._refresh_hdr_slider_visibility()
 
             mirror_idx = 0
             if mon.mirror_of in self._mirror_values:
@@ -593,10 +788,10 @@ class MonitorCard(Gtk.Box):
                 self._pos_row,
                 self._mirror_row,
                 self._cm_row,
-                self._sdr_row,
                 self._bitdepth_row,
                 self._vrr_row,
                 self._identify_row,
+                *self._hdr_slider_rows,
             ):
                 if row is not None:
                     self._update_row(row, all_dirty, managed)
@@ -614,11 +809,6 @@ class MonitorCard(Gtk.Box):
                 (self._pos_row, mon.x != baseline.x or mon.y != baseline.y),
                 (self._mirror_row, mon.mirror_of != baseline.mirror_of),
                 (self._cm_row, mon.color_management != baseline.color_management),
-                (
-                    self._sdr_row,
-                    mon.sdr_brightness != baseline.sdr_brightness
-                    or mon.sdr_saturation != baseline.sdr_saturation,
-                ),
                 (self._bitdepth_row, mon.bit_depth != baseline.bit_depth),
                 (self._vrr_row, mon.vrr != baseline.vrr),
                 (
@@ -626,6 +816,8 @@ class MonitorCard(Gtk.Box):
                     mon.identify_by_description != baseline.identify_by_description,
                 ),
             ]
+            for row, field in zip(self._hdr_slider_rows, HDR_SLIDER_FIELDS, strict=True):
+                fields.append((row, _monitor_extra(mon, field) != _monitor_extra(baseline, field)))
             for row, dirty in fields:
                 if row is None:
                     continue
@@ -645,6 +837,49 @@ class MonitorCard(Gtk.Box):
                 is_saved=managed,
                 show_reset=False,
             )
+
+    def _is_hdr_lock_active(self) -> bool:
+        return getattr(self, "_hdr_lock_active", False)
+
+    def _set_hdr_lock_active(self, active: bool):
+        self._hdr_lock_active = active
+        with self._signals:
+            for button in self._hdr_lock_buttons.values():
+                button.set_active(active)
+                image = button.get_child()
+                if isinstance(image, Gtk.Image):
+                    image.set_from_icon_name(HDR_LOCKED_ICON if active else HDR_UNLOCKED_ICON)
+
+    def _format_hdr_field_value(self, field: str, value: float) -> str | None:
+        spec = HDR_SLIDER_SPEC_BY_FIELD[field]
+        return _format_hdr_value(value, spec.default, spec.digits)
+
+    def _format_hdr_safe_value(self, field: str) -> str | None:
+        spec = HDR_SLIDER_SPEC_BY_FIELD[field]
+        if spec.auto_default:
+            return None
+        return _format_hdr_raw_value(spec.default, spec.digits)
+
+    def _default_hdr_values(self) -> dict[str, str | None]:
+        return {field: self._format_hdr_safe_value(field) for field in HDR_RESET_FIELDS}
+
+    def _missing_hdr_default_values(self) -> dict[str, str | None]:
+        return {
+            field: self._format_hdr_safe_value(field)
+            for field in HDR_RESET_FIELDS
+            if _monitor_extra(self._monitor, field) is None
+        }
+
+    def _set_hdr_slider_value(self, field: str, value: float) -> float:
+        spec = HDR_SLIDER_SPEC_BY_FIELD[field]
+        clamped = max(spec.minimum, min(spec.maximum, value))
+        slider = self._hdr_sliders.get(field)
+        if slider is not None and abs(slider.get_value() - clamped) > 1e-6:
+            slider.set_value(clamped)
+        label = self._hdr_value_labels.get(field)
+        if label is not None:
+            label.set_label(self._format_hdr_label(clamped, spec))
+        return clamped
 
     # -- Signal handlers --
 
@@ -678,17 +913,52 @@ class MonitorCard(Gtk.Box):
 
     def _on_cm_changed(self, row: Adw.ComboRow, *_args):
         idx = row.get_selected()
-        self._emit({"color_management": CM_VALUES[idx] if idx < len(CM_VALUES) else None})
-        self._refresh_sdr_visibility()
+        value = CM_VALUES[idx] if idx < len(CM_VALUES) else None
+        new_vals = {"color_management": value}
+        if value in _HDR_CM_VALUES:
+            new_vals.update(self._missing_hdr_default_values())
+        self._emit(new_vals)
+        self._refresh_hdr_slider_visibility()
 
-    def _on_sdr_changed(self, *_args):
-        new_vals: dict = {}
-        if self._sdr_brightness is not None:
-            new_vals["sdr_brightness"] = _format_sdr(self._sdr_brightness.get_value())
-        if self._sdr_saturation is not None:
-            new_vals["sdr_saturation"] = _format_sdr(self._sdr_saturation.get_value())
+    def _on_hdr_lock_toggled(self, button: Gtk.ToggleButton, field: str):
+        self._set_hdr_lock_active(button.get_active())
+        if not self._is_hdr_lock_active():
+            return
+
+        new_vals: dict[str, str | None] = {}
+        with self._signals:
+            for sdr_field, hdr_field in (
+                ("sdr_min_luminance", "min_luminance"),
+                ("sdr_max_luminance", "max_luminance"),
+            ):
+                source_field = field if field in {sdr_field, hdr_field} else sdr_field
+                target_field = hdr_field if source_field == sdr_field else sdr_field
+                source_slider = self._hdr_sliders.get(source_field)
+                if source_slider is None:
+                    continue
+                value = self._set_hdr_slider_value(target_field, source_slider.get_value())
+                new_vals[target_field] = self._format_hdr_field_value(target_field, value)
         if new_vals:
             self._emit(new_vals)
+
+    def _on_hdr_reset_clicked(self, *_args):
+        with self._signals:
+            for spec in HDR_SLIDER_SPECS:
+                self._set_hdr_slider_value(spec.field, spec.default)
+        self._emit(self._default_hdr_values())
+
+    def _on_hdr_slider_changed(self, scale: Gtk.Scale, spec: _HdrSliderSpec):
+        value = scale.get_value()
+        self._set_hdr_slider_value(spec.field, value)
+        new_vals = {spec.field: _format_hdr_value(value, spec.default, spec.digits)}
+
+        peer_field = LOCKED_LUMINANCE_PAIRS.get(spec.field)
+        if self._is_hdr_lock_active() and peer_field is not None:
+            with self._signals:
+                peer_value = self._set_hdr_slider_value(peer_field, value)
+            new_vals[peer_field] = self._format_hdr_field_value(peer_field, peer_value)
+
+        self._emit(new_vals)
 
     def _on_mirror_changed(self, *_args):
         idx = self._mirror_row.get_selected()

--- a/hyprmod/pages/monitors/card.py
+++ b/hyprmod/pages/monitors/card.py
@@ -1,6 +1,6 @@
 """Editable card widget for a single monitor."""
 
-from dataclasses import dataclass
+from dataclasses import dataclass, replace
 
 from gi.repository import Adw, Gtk
 from hyprland_monitors.monitors import (
@@ -86,6 +86,7 @@ HDR_SLIDER_SPECS = (
         0.05,
         0.1,
         2,
+        auto_default=True,
     ),
     _HdrSliderSpec(
         "sdr_max_luminance",
@@ -97,6 +98,7 @@ HDR_SLIDER_SPECS = (
         10.0,
         100.0,
         0,
+        auto_default=True,
     ),
     _HdrSliderSpec(
         "min_luminance",
@@ -108,6 +110,7 @@ HDR_SLIDER_SPECS = (
         0.05,
         0.1,
         2,
+        auto_default=True,
     ),
     _HdrSliderSpec(
         "max_luminance",
@@ -119,6 +122,7 @@ HDR_SLIDER_SPECS = (
         10.0,
         100.0,
         0,
+        auto_default=True,
     ),
     _HdrSliderSpec(
         "max_avg_luminance",
@@ -136,6 +140,40 @@ HDR_SLIDER_SPECS = (
 )
 HDR_SLIDER_FIELDS = tuple(spec.field for spec in HDR_SLIDER_SPECS)
 HDR_SLIDER_SPEC_BY_FIELD = {spec.field: spec for spec in HDR_SLIDER_SPECS}
+
+# EDID-derived caps that supply the "Auto" slider position per HDR luminance field.
+# Both SDR and HDR variants of min/max share the same EDID source — Hyprland reads
+# one panel mastering range and uses it for both SDR-to-HDR mapping and HDR output.
+# Fields not in this mapping use their static spec.default as the Auto position.
+_CAPS_DEFAULT_SOURCE: dict[str, str] = {
+    "sdr_min_luminance": "min_luminance",
+    "sdr_max_luminance": "max_luminance",
+    "min_luminance": "min_luminance",
+    "max_luminance": "max_luminance",
+    "max_avg_luminance": "max_avg_luminance",
+}
+
+
+def _resolve_hdr_specs(caps: dict) -> tuple[_HdrSliderSpec, ...]:
+    """Return per-monitor specs, substituting EDID values for the Auto slider position.
+
+    For each slider field that has a ``_CAPS_DEFAULT_SOURCE`` entry, if the caps
+    dict carries a real (non-None) value, the returned spec has ``default``
+    replaced with it — so the slider's Auto position lines up with the panel's
+    EDID-reported mastering luminance. Fields without caps coverage, or fields
+    whose caps value is ``None``, fall through to the static template default.
+    """
+    resolved: list[_HdrSliderSpec] = []
+    for template in HDR_SLIDER_SPECS:
+        caps_field = _CAPS_DEFAULT_SOURCE.get(template.field)
+        edid_value = caps.get(caps_field) if caps_field else None
+        if edid_value is not None:
+            resolved.append(replace(template, default=float(edid_value)))
+        else:
+            resolved.append(template)
+    return tuple(resolved)
+
+
 HDR_RESET_FIELDS = HDR_SLIDER_FIELDS
 LOCKED_LUMINANCE_PAIRS = {
     "sdr_min_luminance": "min_luminance",
@@ -171,26 +209,38 @@ def _format_sdr(value: float) -> str | None:
     return _format_hdr_value(value, SDR_VALUE_DEFAULT, SDR_VALUE_DIGITS)
 
 
-def _format_hdr_value(value: float, default: float, digits: int) -> str | None:
-    """Format a slider value back into config-line form, or None at the default."""
-    # Epsilon handles FP jitter from the slider; picking the exact default resets.
-    if abs(value - default) < 1e-3:
-        return None
-    int_part, _, frac = f"{value:.{digits}f}".partition(".")
-    frac = frac.rstrip("0")
-    return f"{int_part}.{frac}" if frac else int_part
-
-
 def _format_hdr_raw_value(value: float, digits: int) -> str:
+    """Format a float as a config-line value at slider precision (no None special-case)."""
     int_part, _, frac = f"{value:.{digits}f}".partition(".")
     frac = frac.rstrip("0")
     return f"{int_part}.{frac}" if frac else int_part
+
+
+def _format_hdr_value(
+    value: float, default: float, digits: int, auto_default: bool = False
+) -> str | None:
+    """Format a slider value back into config-line form.
+
+    For fields whose ``spec.default`` is a real value worth writing to disk
+    (``auto_default=True`` — luminance fields where ``spec.default`` is the
+    panel's EDID mastering luminance), always emits the formatted value. For
+    fields whose ``spec.default`` is Hyprland's own no-override default
+    (``auto_default=False`` — ``sdrbrightness`` / ``sdrsaturation`` where the
+    default of ``1`` is what Hyprland uses anyway), returns ``None`` at the
+    default so the line gets omitted from the saved config.
+
+    The live ``hl.monitor()`` apply emits explicit defaults for the
+    ``auto_default=False`` fields via ``explicit_hdr_defaults=True`` in
+    hyprland-state, which handles the additive-omission reset there.
+    """
+    if not auto_default and abs(value - default) < 1e-3:
+        # Epsilon handles FP jitter from the slider; picking the exact default resets.
+        return None
+    return _format_hdr_raw_value(value, digits)
 
 
 def _format_hdr_display_value(value: float, spec: _HdrSliderSpec) -> str:
-    """Format the visible slider value label."""
-    if spec.auto_default and abs(value - spec.default) < 1e-3:
-        return "Auto"
+    """Format the visible slider value label at slider precision."""
     digits = spec.display_digits if spec.display_digits is not None else spec.digits
     return f"{value:.{digits}f}"
 
@@ -217,6 +267,13 @@ class MonitorCard(Gtk.Box):
         self._caps = caps or {"hdr": False, "ten_bit": False, "vrr": False}
         self._mirror_choices = mirror_choices or []
         self._desc_unique = desc_unique
+        # Per-monitor HDR specs with EDID-derived Auto positions substituted in
+        # where the panel reports mastering luminance. Falls back to the static
+        # template defaults for monitors without HDR caps or EDID coverage.
+        self._hdr_specs = _resolve_hdr_specs(self._caps)
+        self._hdr_specs_by_field: dict[str, _HdrSliderSpec] = {
+            s.field: s for s in self._hdr_specs
+        }
 
         connector = monitor.name
         make = monitor.make
@@ -608,7 +665,7 @@ class MonitorCard(Gtk.Box):
             return []
 
         rows: list[Adw.ActionRow] = []
-        for spec in HDR_SLIDER_SPECS:
+        for spec in self._hdr_specs:
             value = _parse_hdr_value(getattr(monitor, spec.field), spec.default)
             row = Adw.ActionRow(title=spec.title, subtitle=spec.subtitle)
             scale = self._make_hdr_slider(spec, value)
@@ -636,7 +693,7 @@ class MonitorCard(Gtk.Box):
         if spec.field not in LOCKED_LUMINANCE_FIELD_SET:
             return None
 
-        peer = HDR_SLIDER_SPEC_BY_FIELD[LOCKED_LUMINANCE_PAIRS[spec.field]]
+        peer = self._hdr_specs_by_field[LOCKED_LUMINANCE_PAIRS[spec.field]]
         button = Gtk.ToggleButton()
         button.set_child(Gtk.Image.new_from_icon_name(HDR_UNLOCKED_ICON))
         button.set_valign(Gtk.Align.CENTER)
@@ -662,8 +719,10 @@ class MonitorCard(Gtk.Box):
         scale.set_draw_value(False)
         scale.set_size_request(220, -1)
         scale.set_valign(Gtk.Align.CENTER)
-        if spec.field in {"sdr_brightness", "sdr_saturation"}:
-            scale.add_mark(SDR_VALUE_DEFAULT, Gtk.PositionType.BOTTOM, None)
+        # Tick mark at the recommended default — Hyprland's 1.0 ideal for SDR
+        # brightness/saturation, the panel's EDID position for the luminance
+        # sliders. Visually anchors the "Auto" label.
+        scale.add_mark(spec.default, Gtk.PositionType.BOTTOM, None)
         return scale
 
     def _is_hdr_cm_active(self) -> bool:
@@ -733,7 +792,7 @@ class MonitorCard(Gtk.Box):
             if self._cm_row:
                 c = mon.color_management
                 self._cm_row.set_selected(CM_VALUES.index(c) if c in CM_VALUES else 0)
-            for spec in HDR_SLIDER_SPECS:
+            for spec in self._hdr_specs:
                 slider = self._hdr_sliders.get(spec.field)
                 if slider is None:
                     continue
@@ -850,12 +909,20 @@ class MonitorCard(Gtk.Box):
                     image.set_from_icon_name(HDR_LOCKED_ICON if active else HDR_UNLOCKED_ICON)
 
     def _format_hdr_field_value(self, field: str, value: float) -> str | None:
-        spec = HDR_SLIDER_SPEC_BY_FIELD[field]
-        return _format_hdr_value(value, spec.default, spec.digits)
+        spec = self._hdr_specs_by_field[field]
+        return _format_hdr_value(value, spec.default, spec.digits, spec.auto_default)
 
     def _format_hdr_safe_value(self, field: str) -> str | None:
-        spec = HDR_SLIDER_SPEC_BY_FIELD[field]
-        if spec.auto_default:
+        """Return the value to write to config when resetting this field.
+
+        Mirrors ``_format_hdr_value`` at ``spec.default``: emit the value for
+        ``auto_default=True`` fields (so the config carries the panel's EDID
+        luminance explicitly — Hyprland's no-override default for these is
+        wrong); return ``None`` for fields whose Hyprland default is correct
+        and can be left unwritten.
+        """
+        spec = self._hdr_specs_by_field[field]
+        if not spec.auto_default:
             return None
         return _format_hdr_raw_value(spec.default, spec.digits)
 
@@ -870,7 +937,7 @@ class MonitorCard(Gtk.Box):
         }
 
     def _set_hdr_slider_value(self, field: str, value: float) -> float:
-        spec = HDR_SLIDER_SPEC_BY_FIELD[field]
+        spec = self._hdr_specs_by_field[field]
         clamped = max(spec.minimum, min(spec.maximum, value))
         slider = self._hdr_sliders.get(field)
         if slider is not None and abs(slider.get_value() - clamped) > 1e-6:
@@ -942,14 +1009,16 @@ class MonitorCard(Gtk.Box):
 
     def _on_hdr_reset_clicked(self, *_args):
         with self._signals:
-            for spec in HDR_SLIDER_SPECS:
+            for spec in self._hdr_specs:
                 self._set_hdr_slider_value(spec.field, spec.default)
         self._emit(self._default_hdr_values())
 
     def _on_hdr_slider_changed(self, scale: Gtk.Scale, spec: _HdrSliderSpec):
         value = scale.get_value()
         self._set_hdr_slider_value(spec.field, value)
-        new_vals = {spec.field: _format_hdr_value(value, spec.default, spec.digits)}
+        new_vals = {
+            spec.field: _format_hdr_value(value, spec.default, spec.digits, spec.auto_default)
+        }
 
         peer_field = LOCKED_LUMINANCE_PAIRS.get(spec.field)
         if self._is_hdr_lock_active() and peer_field is not None:

--- a/hyprmod/pages/monitors/card.py
+++ b/hyprmod/pages/monitors/card.py
@@ -195,10 +195,6 @@ def _format_hdr_display_value(value: float, spec: _HdrSliderSpec) -> str:
     return f"{value:.{digits}f}"
 
 
-def _monitor_extra(mon: MonitorState, field: str) -> str | None:
-    return getattr(mon, field, None)
-
-
 class MonitorCard(Gtk.Box):
     """Editable card for a single monitor."""
 
@@ -613,7 +609,7 @@ class MonitorCard(Gtk.Box):
 
         rows: list[Adw.ActionRow] = []
         for spec in HDR_SLIDER_SPECS:
-            value = _parse_hdr_value(_monitor_extra(monitor, spec.field), spec.default)
+            value = _parse_hdr_value(getattr(monitor, spec.field), spec.default)
             row = Adw.ActionRow(title=spec.title, subtitle=spec.subtitle)
             scale = self._make_hdr_slider(spec, value)
             value_label = Gtk.Label(
@@ -741,7 +737,7 @@ class MonitorCard(Gtk.Box):
                 slider = self._hdr_sliders.get(spec.field)
                 if slider is None:
                     continue
-                value = _parse_hdr_value(_monitor_extra(mon, spec.field), spec.default)
+                value = _parse_hdr_value(getattr(mon, spec.field), spec.default)
                 slider.set_value(value)
                 label = self._hdr_value_labels.get(spec.field)
                 if label is not None:
@@ -816,8 +812,11 @@ class MonitorCard(Gtk.Box):
                     mon.identify_by_description != baseline.identify_by_description,
                 ),
             ]
-            for row, field in zip(self._hdr_slider_rows, HDR_SLIDER_FIELDS, strict=True):
-                fields.append((row, _monitor_extra(mon, field) != _monitor_extra(baseline, field)))
+            # Rows are built only when the monitor reports HDR capability;
+            # skip when absent so the strict zip stays meaningful for the HDR path.
+            if self._hdr_slider_rows:
+                for row, field in zip(self._hdr_slider_rows, HDR_SLIDER_FIELDS, strict=True):
+                    fields.append((row, getattr(mon, field) != getattr(baseline, field)))
             for row, dirty in fields:
                 if row is None:
                     continue
@@ -867,7 +866,7 @@ class MonitorCard(Gtk.Box):
         return {
             field: self._format_hdr_safe_value(field)
             for field in HDR_RESET_FIELDS
-            if _monitor_extra(self._monitor, field) is None
+            if getattr(self._monitor, field) is None
         }
 
     def _set_hdr_slider_value(self, field: str, value: float) -> float:

--- a/hyprmod/pages/monitors/card.py
+++ b/hyprmod/pages/monitors/card.py
@@ -51,16 +51,19 @@ class _HdrSliderSpec:
 
 
 HDR_SLIDER_SPECS = (
+    # Hyprland's 1.0 sdr_brightness over-brightens SDR-in-HDR;
+    # 0.5 is the community recommended starting point
     _HdrSliderSpec(
         field="sdr_brightness",
         title="SDR Brightness",
         subtitle="Brightness for SDR content in HDR mode",
-        default=SDR_VALUE_DEFAULT,
+        default=0.5,
         minimum=SDR_VALUE_MIN,
         maximum=SDR_VALUE_MAX,
         step=SDR_VALUE_STEP,
         page=SDR_VALUE_STEP * 4,
         digits=SDR_VALUE_DIGITS,
+        auto_default=True,
     ),
     _HdrSliderSpec(
         field="sdr_saturation",

--- a/hyprmod/pages/monitors/card.py
+++ b/hyprmod/pages/monitors/card.py
@@ -47,95 +47,91 @@ class _HdrSliderSpec:
     step: float
     page: float
     digits: int
-    display_digits: int | None = None
     auto_default: bool = False
 
 
 HDR_SLIDER_SPECS = (
     _HdrSliderSpec(
-        "sdr_brightness",
-        "SDR Brightness",
-        "Brightness for SDR content in HDR mode",
-        SDR_VALUE_DEFAULT,
-        SDR_VALUE_MIN,
-        SDR_VALUE_MAX,
-        SDR_VALUE_STEP,
-        SDR_VALUE_STEP * 4,
-        SDR_VALUE_DIGITS,
-        2,
+        field="sdr_brightness",
+        title="SDR Brightness",
+        subtitle="Brightness for SDR content in HDR mode",
+        default=SDR_VALUE_DEFAULT,
+        minimum=SDR_VALUE_MIN,
+        maximum=SDR_VALUE_MAX,
+        step=SDR_VALUE_STEP,
+        page=SDR_VALUE_STEP * 4,
+        digits=SDR_VALUE_DIGITS,
     ),
     _HdrSliderSpec(
-        "sdr_saturation",
-        "SDR Saturation",
-        "Saturation for SDR content in HDR mode",
-        SDR_VALUE_DEFAULT,
-        SDR_VALUE_MIN,
-        SDR_VALUE_MAX,
-        SDR_VALUE_STEP,
-        SDR_VALUE_STEP * 4,
-        SDR_VALUE_DIGITS,
-        2,
+        field="sdr_saturation",
+        title="SDR Saturation",
+        subtitle="Saturation for SDR content in HDR mode",
+        default=SDR_VALUE_DEFAULT,
+        minimum=SDR_VALUE_MIN,
+        maximum=SDR_VALUE_MAX,
+        step=SDR_VALUE_STEP,
+        page=SDR_VALUE_STEP * 4,
+        digits=SDR_VALUE_DIGITS,
     ),
     _HdrSliderSpec(
-        "sdr_min_luminance",
-        "SDR Min Luminance",
-        "Minimum luminance for SDR to HDR mapping",
-        0.0,
-        0.0,
-        1.0,
-        0.05,
-        0.1,
-        2,
+        field="sdr_min_luminance",
+        title="SDR Min Luminance",
+        subtitle="Minimum luminance for SDR to HDR mapping",
+        default=0.0,
+        minimum=0.0,
+        maximum=1.0,
+        step=0.05,
+        page=0.1,
+        digits=2,
         auto_default=True,
     ),
     _HdrSliderSpec(
-        "sdr_max_luminance",
-        "SDR Max Luminance",
-        "Maximum luminance for SDR content",
-        800.0,
-        0.0,
-        2000.0,
-        10.0,
-        100.0,
-        0,
+        field="sdr_max_luminance",
+        title="SDR Max Luminance",
+        subtitle="Maximum luminance for SDR content",
+        default=800.0,
+        minimum=0.0,
+        maximum=2000.0,
+        step=10.0,
+        page=100.0,
+        digits=0,
         auto_default=True,
     ),
     _HdrSliderSpec(
-        "min_luminance",
-        "HDR Min Luminance",
-        "Minimum luminance for HDR output",
-        0.0,
-        0.0,
-        1.0,
-        0.05,
-        0.1,
-        2,
+        field="min_luminance",
+        title="HDR Min Luminance",
+        subtitle="Minimum luminance for HDR output",
+        default=0.0,
+        minimum=0.0,
+        maximum=1.0,
+        step=0.05,
+        page=0.1,
+        digits=2,
         auto_default=True,
     ),
     _HdrSliderSpec(
-        "max_luminance",
-        "HDR Max Luminance",
-        "Maximum luminance for HDR output",
-        800.0,
-        0.0,
-        2000.0,
-        10.0,
-        100.0,
-        0,
+        field="max_luminance",
+        title="HDR Max Luminance",
+        subtitle="Maximum luminance for HDR output",
+        default=800.0,
+        minimum=0.0,
+        maximum=2000.0,
+        step=10.0,
+        page=100.0,
+        digits=0,
         auto_default=True,
     ),
     _HdrSliderSpec(
-        "max_avg_luminance",
-        "Max Avg Luminance",
-        "Monitor maximum average luminance",
-        500.0,
-        0.0,
-        2000.0,
-        10.0,
-        100.0,
-        0,
-        None,
-        True,
+        field="max_avg_luminance",
+        title="Max Avg Luminance",
+        subtitle="Monitor maximum average luminance",
+        default=500.0,
+        minimum=0.0,
+        maximum=2000.0,
+        step=10.0,
+        page=100.0,
+        digits=0,
+        auto_default=True,
     ),
 )
 HDR_SLIDER_FIELDS = tuple(spec.field for spec in HDR_SLIDER_SPECS)
@@ -174,21 +170,16 @@ def _resolve_hdr_specs(caps: dict) -> tuple[_HdrSliderSpec, ...]:
     return tuple(resolved)
 
 
-HDR_RESET_FIELDS = HDR_SLIDER_FIELDS
-LOCKED_LUMINANCE_PAIRS = {
-    "sdr_min_luminance": "min_luminance",
-    "min_luminance": "sdr_min_luminance",
-    "sdr_max_luminance": "max_luminance",
-    "max_luminance": "sdr_max_luminance",
+LUMINANCE_PAIRS: tuple[tuple[str, str], ...] = (
+    ("sdr_min_luminance", "min_luminance"),
+    ("sdr_max_luminance", "max_luminance"),
+)
+LOCKED_LUMINANCE_PEER: dict[str, str] = {
+    field: peer for pair in LUMINANCE_PAIRS for field, peer in (pair, pair[::-1])
 }
-LOCKED_LUMINANCE_FIELD_SET = frozenset(LOCKED_LUMINANCE_PAIRS)
+LOCKED_LUMINANCE_FIELD_SET = frozenset(LOCKED_LUMINANCE_PEER)
 HDR_LOCKED_ICON = "changes-prevent-symbolic"
 HDR_UNLOCKED_ICON = "changes-allow-symbolic"
-
-
-def _parse_sdr(value: str | None) -> float:
-    """Parse a stored sdr_brightness/sdr_saturation string into a slider value."""
-    return _parse_hdr_value(value, SDR_VALUE_DEFAULT)
 
 
 def _parse_hdr_value(value: str | None, default: float) -> float:
@@ -199,14 +190,6 @@ def _parse_hdr_value(value: str | None, default: float) -> float:
         return float(value)
     except ValueError:
         return default
-
-
-def _format_sdr(value: float) -> str | None:
-    """Format a slider value back into config-line form, or None at the default.
-
-    Keeps at least one integer digit so ``0`` renders as ``"0"`` rather than ``""``.
-    """
-    return _format_hdr_value(value, SDR_VALUE_DEFAULT, SDR_VALUE_DIGITS)
 
 
 def _format_hdr_raw_value(value: float, digits: int) -> str:
@@ -241,8 +224,7 @@ def _format_hdr_value(
 
 def _format_hdr_display_value(value: float, spec: _HdrSliderSpec) -> str:
     """Format the visible slider value label at slider precision."""
-    digits = spec.display_digits if spec.display_digits is not None else spec.digits
-    return f"{value:.{digits}f}"
+    return f"{value:.{spec.digits}f}"
 
 
 class MonitorCard(Gtk.Box):
@@ -642,25 +624,25 @@ class MonitorCard(Gtk.Box):
         return row
 
     def _build_hdr_reset_row(self) -> Adw.ActionRow | None:
-        self._hdr_reset_button: Gtk.Button | None = None
         if not self._caps.get("hdr"):
             return None
 
         row = Adw.ActionRow(title="Safe Defaults", subtitle="Restore conservative HDR values")
-        self._hdr_reset_button = Gtk.Button(icon_name="edit-undo-symbolic")
-        self._hdr_reset_button.set_valign(Gtk.Align.CENTER)
-        self._hdr_reset_button.set_tooltip_text("Apply safe defaults")
-        self._hdr_reset_button.add_css_class("flat")
-        row.add_suffix(self._hdr_reset_button)
-        self._signals.connect(self._hdr_reset_button, "clicked", self._on_hdr_reset_clicked)
+        button = Gtk.Button(icon_name="edit-undo-symbolic")
+        button.set_valign(Gtk.Align.CENTER)
+        button.set_tooltip_text("Apply safe defaults")
+        button.add_css_class("flat")
+        row.add_suffix(button)
+        self._signals.connect(button, "clicked", self._on_hdr_reset_clicked)
         return row
 
     def _build_hdr_slider_rows(self, monitor: MonitorState) -> list[Adw.ActionRow]:
         """Build one slider row for each HDR-related monitor value."""
         self._hdr_sliders: dict[str, Gtk.Scale] = {}
         self._hdr_value_labels: dict[str, Gtk.Label] = {}
-        self._hdr_lock_active = False
+        self._hdr_locked_fields: set[str] = set()
         self._hdr_lock_buttons: dict[str, Gtk.ToggleButton] = {}
+        self._hdr_lock_icons: dict[str, Gtk.Image] = {}
         if not self._caps.get("hdr"):
             return []
 
@@ -670,7 +652,7 @@ class MonitorCard(Gtk.Box):
             row = Adw.ActionRow(title=spec.title, subtitle=spec.subtitle)
             scale = self._make_hdr_slider(spec, value)
             value_label = Gtk.Label(
-                label=self._format_hdr_label(value, spec),
+                label=_format_hdr_display_value(value, spec),
                 width_chars=SLIDER_VALUE_WIDTH_CHARS,
                 xalign=1,
             )
@@ -693,14 +675,16 @@ class MonitorCard(Gtk.Box):
         if spec.field not in LOCKED_LUMINANCE_FIELD_SET:
             return None
 
-        peer = self._hdr_specs_by_field[LOCKED_LUMINANCE_PAIRS[spec.field]]
+        peer = self._hdr_specs_by_field[LOCKED_LUMINANCE_PEER[spec.field]]
+        icon = Gtk.Image.new_from_icon_name(HDR_UNLOCKED_ICON)
         button = Gtk.ToggleButton()
-        button.set_child(Gtk.Image.new_from_icon_name(HDR_UNLOCKED_ICON))
+        button.set_child(icon)
         button.set_valign(Gtk.Align.CENTER)
-        button.set_active(self._hdr_lock_active)
+        button.set_active(False)
         button.set_tooltip_text(f"Lock {spec.title} with {peer.title}")
         button.add_css_class("flat")
         self._hdr_lock_buttons[spec.field] = button
+        self._hdr_lock_icons[spec.field] = icon
         self._signals.connect(button, "toggled", self._on_hdr_lock_toggled, spec.field)
         return button
 
@@ -740,9 +724,6 @@ class MonitorCard(Gtk.Box):
             self._hdr_reset_row.set_visible(visible)
         for row in self._hdr_slider_rows:
             row.set_visible(visible)
-
-    def _format_hdr_label(self, value: float, spec: _HdrSliderSpec) -> str:
-        return _format_hdr_display_value(value, spec)
 
     def _attach_row_actions(self, row: Adw.ActionRow | Adw.ComboRow, discard_handler):
         """Attach a RowActions strip (discard only, no per-row remove)."""
@@ -800,7 +781,7 @@ class MonitorCard(Gtk.Box):
                 slider.set_value(value)
                 label = self._hdr_value_labels.get(spec.field)
                 if label is not None:
-                    label.set_label(self._format_hdr_label(value, spec))
+                    label.set_label(_format_hdr_display_value(value, spec))
             self._refresh_hdr_slider_visibility()
 
             mirror_idx = 0
@@ -896,43 +877,42 @@ class MonitorCard(Gtk.Box):
                 show_reset=False,
             )
 
-    def _is_hdr_lock_active(self) -> bool:
-        return getattr(self, "_hdr_lock_active", False)
-
-    def _set_hdr_lock_active(self, active: bool):
-        self._hdr_lock_active = active
+    def _set_pair_lock(self, field: str, peer: str, active: bool):
+        """Update lock state for one luminance pair and its two button icons."""
+        if active:
+            self._hdr_locked_fields.update((field, peer))
+        else:
+            self._hdr_locked_fields.difference_update((field, peer))
+        icon_name = HDR_LOCKED_ICON if active else HDR_UNLOCKED_ICON
         with self._signals:
-            for button in self._hdr_lock_buttons.values():
-                button.set_active(active)
-                image = button.get_child()
-                if isinstance(image, Gtk.Image):
-                    image.set_from_icon_name(HDR_LOCKED_ICON if active else HDR_UNLOCKED_ICON)
+            for f in (field, peer):
+                button = self._hdr_lock_buttons.get(f)
+                if button is not None:
+                    button.set_active(active)
+                icon = self._hdr_lock_icons.get(f)
+                if icon is not None:
+                    icon.set_from_icon_name(icon_name)
 
     def _format_hdr_field_value(self, field: str, value: float) -> str | None:
+        """Return the config-line value for ``field`` at ``value`` (or None to omit).
+
+        Passing ``spec.default`` as ``value`` produces the safe-reset value:
+        the explicit EDID luminance for ``auto_default=True`` fields, and
+        ``None`` for fields whose Hyprland no-override default is correct.
+        """
         spec = self._hdr_specs_by_field[field]
         return _format_hdr_value(value, spec.default, spec.digits, spec.auto_default)
 
-    def _format_hdr_safe_value(self, field: str) -> str | None:
-        """Return the value to write to config when resetting this field.
-
-        Mirrors ``_format_hdr_value`` at ``spec.default``: emit the value for
-        ``auto_default=True`` fields (so the config carries the panel's EDID
-        luminance explicitly — Hyprland's no-override default for these is
-        wrong); return ``None`` for fields whose Hyprland default is correct
-        and can be left unwritten.
-        """
-        spec = self._hdr_specs_by_field[field]
-        if not spec.auto_default:
-            return None
-        return _format_hdr_raw_value(spec.default, spec.digits)
-
     def _default_hdr_values(self) -> dict[str, str | None]:
-        return {field: self._format_hdr_safe_value(field) for field in HDR_RESET_FIELDS}
+        return {
+            field: self._format_hdr_field_value(field, self._hdr_specs_by_field[field].default)
+            for field in HDR_SLIDER_FIELDS
+        }
 
     def _missing_hdr_default_values(self) -> dict[str, str | None]:
         return {
-            field: self._format_hdr_safe_value(field)
-            for field in HDR_RESET_FIELDS
+            field: self._format_hdr_field_value(field, self._hdr_specs_by_field[field].default)
+            for field in HDR_SLIDER_FIELDS
             if getattr(self._monitor, field) is None
         }
 
@@ -944,7 +924,7 @@ class MonitorCard(Gtk.Box):
             slider.set_value(clamped)
         label = self._hdr_value_labels.get(field)
         if label is not None:
-            label.set_label(self._format_hdr_label(clamped, spec))
+            label.set_label(_format_hdr_display_value(clamped, spec))
         return clamped
 
     # -- Signal handlers --
@@ -987,25 +967,24 @@ class MonitorCard(Gtk.Box):
         self._refresh_hdr_slider_visibility()
 
     def _on_hdr_lock_toggled(self, button: Gtk.ToggleButton, field: str):
-        self._set_hdr_lock_active(button.get_active())
-        if not self._is_hdr_lock_active():
+        """Sync the clicked SDR/HDR luminance pair when its lock is enabled.
+
+        Each pair (min/sdr_min and max/sdr_max) has its own lock state, so
+        toggling one pair leaves the other alone. The clicked row is the
+        source so the value the user just set sticks; the peer row follows.
+        """
+        active = button.get_active()
+        peer = LOCKED_LUMINANCE_PEER[field]
+        self._set_pair_lock(field, peer, active)
+        if not active:
             return
 
-        new_vals: dict[str, str | None] = {}
+        source_slider = self._hdr_sliders.get(field)
+        if source_slider is None:
+            return
         with self._signals:
-            for sdr_field, hdr_field in (
-                ("sdr_min_luminance", "min_luminance"),
-                ("sdr_max_luminance", "max_luminance"),
-            ):
-                source_field = field if field in {sdr_field, hdr_field} else sdr_field
-                target_field = hdr_field if source_field == sdr_field else sdr_field
-                source_slider = self._hdr_sliders.get(source_field)
-                if source_slider is None:
-                    continue
-                value = self._set_hdr_slider_value(target_field, source_slider.get_value())
-                new_vals[target_field] = self._format_hdr_field_value(target_field, value)
-        if new_vals:
-            self._emit(new_vals)
+            peer_value = self._set_hdr_slider_value(peer, source_slider.get_value())
+        self._emit({peer: self._format_hdr_field_value(peer, peer_value)})
 
     def _on_hdr_reset_clicked(self, *_args):
         with self._signals:
@@ -1020,8 +999,8 @@ class MonitorCard(Gtk.Box):
             spec.field: _format_hdr_value(value, spec.default, spec.digits, spec.auto_default)
         }
 
-        peer_field = LOCKED_LUMINANCE_PAIRS.get(spec.field)
-        if self._is_hdr_lock_active() and peer_field is not None:
+        peer_field = LOCKED_LUMINANCE_PEER.get(spec.field)
+        if peer_field is not None and spec.field in self._hdr_locked_fields:
             with self._signals:
                 peer_value = self._set_hdr_slider_value(peer_field, value)
             new_vals[peer_field] = self._format_hdr_field_value(peer_field, peer_value)

--- a/hyprmod/pages/monitors/card.py
+++ b/hyprmod/pages/monitors/card.py
@@ -253,9 +253,7 @@ class MonitorCard(Gtk.Box):
         # where the panel reports mastering luminance. Falls back to the static
         # template defaults for monitors without HDR caps or EDID coverage.
         self._hdr_specs = _resolve_hdr_specs(self._caps)
-        self._hdr_specs_by_field: dict[str, _HdrSliderSpec] = {
-            s.field: s for s in self._hdr_specs
-        }
+        self._hdr_specs_by_field: dict[str, _HdrSliderSpec] = {s.field: s for s in self._hdr_specs}
 
         connector = monitor.name
         make = monitor.make

--- a/hyprmod/pages/monitors/page.py
+++ b/hyprmod/pages/monitors/page.py
@@ -2,9 +2,7 @@
 
 import copy
 from collections.abc import Iterator
-from dataclasses import fields as dataclass_fields
 
-import hyprland_monitors.monitors as monitor_lib
 from gi.repository import Adw, GLib, Gtk
 from hyprland_monitors import get_monitor_capabilities
 from hyprland_monitors.monitors import (
@@ -35,42 +33,21 @@ from hyprmod.ui.icons import MONITORS_ICON
 from hyprmod.ui.monitor_preview import MonitorLayoutPreview
 from hyprmod.ui.timer import Timer
 
-_EXTRA_CONFIG_FIELDS = {
-    "bitdepth": "bit_depth",
-    "vrr": "vrr",
-    "cm": "color_management",
-    "sdrbrightness": "sdr_brightness",
-    "sdrsaturation": "sdr_saturation",
-    "sdr_min_luminance": "sdr_min_luminance",
-    "sdr_max_luminance": "sdr_max_luminance",
-    "min_luminance": "min_luminance",
-    "max_luminance": "max_luminance",
-    "max_avg_luminance": "max_avg_luminance",
-}
-
-for _config_key, _field_name in _EXTRA_CONFIG_FIELDS.items():
-    monitor_lib._CONFIG_TO_FIELD.setdefault(_config_key, _field_name)
-
-_EXTRA_FIELDS = (*dict.fromkeys(_EXTRA_CONFIG_FIELDS.values()), "mirror_of")
-_BASE_MONITOR_FIELDS = tuple(field.name for field in dataclass_fields(MonitorState))
-_ADDED_MONITOR_FIELDS = tuple(field for field in _EXTRA_FIELDS if field not in _BASE_MONITOR_FIELDS)
-
-
-class _ExtendedMonitorState(MonitorState):
-    """MonitorState with slots for newer monitor extras not yet in the dependency."""
-
-    __slots__ = _ADDED_MONITOR_FIELDS
-
-
-def _extend_monitor(mon: MonitorState) -> MonitorState:
-    """Return a MonitorState instance that can hold all extras HyprMod exposes."""
-    if isinstance(mon, _ExtendedMonitorState):
-        return mon
-    values = {field: getattr(mon, field) for field in _BASE_MONITOR_FIELDS}
-    extended = _ExtendedMonitorState(**values)
-    for field in _ADDED_MONITOR_FIELDS:
-        setattr(extended, field, getattr(mon, field, None))
-    return extended
+# Fields cleared on managed monitors that aren't present in the saved config.
+# Kept aligned with hyprland-monitors's monitor-line serialization.
+_EXTRA_FIELDS = (
+    "bit_depth",
+    "vrr",
+    "color_management",
+    "sdr_brightness",
+    "sdr_saturation",
+    "sdr_min_luminance",
+    "sdr_max_luminance",
+    "min_luminance",
+    "max_luminance",
+    "max_avg_luminance",
+    "mirror_of",
+)
 
 
 class MonitorsPage(SectionPage):
@@ -183,10 +160,7 @@ class MonitorsPage(SectionPage):
 
     def _reload_monitors(self, saved_sections=None):
         """Fetch monitors from IPC, snap scales, and merge saved config."""
-        self._monitors = sorted(
-            (_extend_monitor(mon) for mon in self._window.hypr.monitors.get_all() or []),
-            key=lambda m: m.name,
-        )
+        self._monitors = sorted(self._window.hypr.monitors.get_all() or [], key=lambda m: m.name)
         self._snap_scales()
         sections = saved_sections if saved_sections is not None else self._window.saved_sections
         saved = config.collect_section(sections, config.KEYWORD_MONITOR)

--- a/hyprmod/pages/monitors/page.py
+++ b/hyprmod/pages/monitors/page.py
@@ -53,9 +53,7 @@ for _config_key, _field_name in _EXTRA_CONFIG_FIELDS.items():
 
 _EXTRA_FIELDS = (*dict.fromkeys(_EXTRA_CONFIG_FIELDS.values()), "mirror_of")
 _BASE_MONITOR_FIELDS = tuple(field.name for field in dataclass_fields(MonitorState))
-_ADDED_MONITOR_FIELDS = tuple(
-    field for field in _EXTRA_FIELDS if field not in _BASE_MONITOR_FIELDS
-)
+_ADDED_MONITOR_FIELDS = tuple(field for field in _EXTRA_FIELDS if field not in _BASE_MONITOR_FIELDS)
 
 
 class _ExtendedMonitorState(MonitorState):

--- a/hyprmod/pages/monitors/page.py
+++ b/hyprmod/pages/monitors/page.py
@@ -2,7 +2,9 @@
 
 import copy
 from collections.abc import Iterator
+from dataclasses import fields as dataclass_fields
 
+import hyprland_monitors.monitors as monitor_lib
 from gi.repository import Adw, GLib, Gtk
 from hyprland_monitors import get_monitor_capabilities
 from hyprland_monitors.monitors import (
@@ -33,14 +35,44 @@ from hyprmod.ui.icons import MONITORS_ICON
 from hyprmod.ui.monitor_preview import MonitorLayoutPreview
 from hyprmod.ui.timer import Timer
 
-_EXTRA_FIELDS = (
-    "bit_depth",
-    "vrr",
-    "color_management",
-    "sdr_brightness",
-    "sdr_saturation",
-    "mirror_of",
+_EXTRA_CONFIG_FIELDS = {
+    "bitdepth": "bit_depth",
+    "vrr": "vrr",
+    "cm": "color_management",
+    "sdrbrightness": "sdr_brightness",
+    "sdrsaturation": "sdr_saturation",
+    "sdr_min_luminance": "sdr_min_luminance",
+    "sdr_max_luminance": "sdr_max_luminance",
+    "min_luminance": "min_luminance",
+    "max_luminance": "max_luminance",
+    "max_avg_luminance": "max_avg_luminance",
+}
+
+for _config_key, _field_name in _EXTRA_CONFIG_FIELDS.items():
+    monitor_lib._CONFIG_TO_FIELD.setdefault(_config_key, _field_name)
+
+_EXTRA_FIELDS = (*dict.fromkeys(_EXTRA_CONFIG_FIELDS.values()), "mirror_of")
+_BASE_MONITOR_FIELDS = tuple(field.name for field in dataclass_fields(MonitorState))
+_ADDED_MONITOR_FIELDS = tuple(
+    field for field in _EXTRA_FIELDS if field not in _BASE_MONITOR_FIELDS
 )
+
+
+class _ExtendedMonitorState(MonitorState):
+    """MonitorState with slots for newer monitor extras not yet in the dependency."""
+
+    __slots__ = _ADDED_MONITOR_FIELDS
+
+
+def _extend_monitor(mon: MonitorState) -> MonitorState:
+    """Return a MonitorState instance that can hold all extras HyprMod exposes."""
+    if isinstance(mon, _ExtendedMonitorState):
+        return mon
+    values = {field: getattr(mon, field) for field in _BASE_MONITOR_FIELDS}
+    extended = _ExtendedMonitorState(**values)
+    for field in _ADDED_MONITOR_FIELDS:
+        setattr(extended, field, getattr(mon, field, None))
+    return extended
 
 
 class MonitorsPage(SectionPage):
@@ -57,6 +89,13 @@ class MonitorsPage(SectionPage):
         "bit_depth",
         "vrr",
         "color_management",
+        "sdr_brightness",
+        "sdr_saturation",
+        "sdr_min_luminance",
+        "sdr_max_luminance",
+        "min_luminance",
+        "max_luminance",
+        "max_avg_luminance",
         "mirror_of",
         "disabled",
         "identify_by_description",
@@ -146,7 +185,10 @@ class MonitorsPage(SectionPage):
 
     def _reload_monitors(self, saved_sections=None):
         """Fetch monitors from IPC, snap scales, and merge saved config."""
-        self._monitors = sorted(self._window.hypr.monitors.get_all() or [], key=lambda m: m.name)
+        self._monitors = sorted(
+            (_extend_monitor(mon) for mon in self._window.hypr.monitors.get_all() or []),
+            key=lambda m: m.name,
+        )
         self._snap_scales()
         sections = saved_sections if saved_sections is not None else self._window.saved_sections
         saved = config.collect_section(sections, config.KEYWORD_MONITOR)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,7 +9,7 @@ dependencies = [
     "hyprland-config>=0.6.5",
     "hyprland-schema>=0.6.1",
     "hyprland-state>=0.4.1",
-    "hyprland-monitors>=0.6.0",
+    "hyprland-monitors>=0.7.0",
     "hyprland-socket>=0.12.1",
 ]
 

--- a/tests/test_monitor_card_helpers.py
+++ b/tests/test_monitor_card_helpers.py
@@ -5,60 +5,15 @@ from dataclasses import replace
 from hyprmod.pages.monitors.card import (
     CM_MODES,
     CM_VALUES,
-    HDR_RESET_FIELDS,
     HDR_SLIDER_FIELDS,
     HDR_SLIDER_SPEC_BY_FIELD,
     SDR_VALUE_DEFAULT,
+    SDR_VALUE_DIGITS,
     _format_hdr_display_value,
     _format_hdr_value,
-    _format_sdr,
     _parse_hdr_value,
-    _parse_sdr,
     _resolve_hdr_specs,
 )
-
-
-class TestParseSdr:
-    def test_none_returns_default(self):
-        assert _parse_sdr(None) == SDR_VALUE_DEFAULT
-
-    def test_numeric_string(self):
-        assert _parse_sdr("1.25") == 1.25
-
-    def test_zero(self):
-        assert _parse_sdr("0") == 0.0
-
-    def test_invalid_falls_back_to_default(self):
-        assert _parse_sdr("not a number") == SDR_VALUE_DEFAULT
-
-
-class TestFormatSdr:
-    def test_default_returns_none(self):
-        assert _format_sdr(SDR_VALUE_DEFAULT) is None
-
-    def test_near_default_returns_none(self):
-        # Float-precision jitter around 1.0 — still treated as "default".
-        assert _format_sdr(1.0 + 1e-9) is None
-        assert _format_sdr(1.0 - 1e-9) is None
-
-    def test_just_below_default_emits_value(self):
-        # 0.95 is a valid override the spinner can produce; it must not be swallowed.
-        assert _format_sdr(0.95) == "0.95"
-
-    def test_override_formatted(self):
-        assert _format_sdr(1.2) == "1.2"
-
-    def test_trailing_zero_stripped(self):
-        assert _format_sdr(1.5) == "1.5"
-        assert _format_sdr(0.8) == "0.8"
-
-    def test_two_decimal_places(self):
-        assert _format_sdr(0.98) == "0.98"
-
-    def test_zero_renders_as_zero(self):
-        # Regression: naive rstrip("0").rstrip(".") would produce "" for 0.0,
-        # which then got written as a malformed config line.
-        assert _format_sdr(0.0) == "0"
 
 
 class TestHdrSliderValues:
@@ -74,6 +29,21 @@ class TestHdrSliderValues:
         assert _format_hdr_value(80.0, 80.0, 0) is None
         assert _format_hdr_value(120.0, 80.0, 0) == "120"
         assert _format_hdr_value(0.25, 0.2, 2) == "0.25"
+
+    def test_format_tolerates_fp_jitter_at_default(self):
+        # Slider can land slightly off the default due to FP arithmetic; the
+        # 1e-3 epsilon catches it and still emits None.
+        assert _format_hdr_value(1.0 + 1e-9, SDR_VALUE_DEFAULT, SDR_VALUE_DIGITS) is None
+        assert _format_hdr_value(1.0 - 1e-9, SDR_VALUE_DEFAULT, SDR_VALUE_DIGITS) is None
+
+    def test_format_zero_renders_as_zero(self):
+        # Regression: a naive rstrip("0").rstrip(".") would produce "" for 0.0,
+        # which then got written as a malformed config line.
+        assert _format_hdr_value(0.0, SDR_VALUE_DEFAULT, SDR_VALUE_DIGITS) == "0"
+
+    def test_format_strips_trailing_zeros(self):
+        assert _format_hdr_value(1.5, SDR_VALUE_DEFAULT, SDR_VALUE_DIGITS) == "1.5"
+        assert _format_hdr_value(0.8, SDR_VALUE_DEFAULT, SDR_VALUE_DIGITS) == "0.8"
 
     def test_format_always_emits_for_auto_default_fields(self):
         # auto_default=True (luminance): spec.default is the panel's EDID value;
@@ -160,9 +130,6 @@ class TestHdrSliderValues:
             "max_avg_luminance",
         ):
             assert field in HDR_SLIDER_FIELDS
-
-    def test_reset_fields_cover_all_hdr_sliders(self):
-        assert HDR_RESET_FIELDS == HDR_SLIDER_FIELDS
 
 
 class TestResolveHdrSpecs:

--- a/tests/test_monitor_card_helpers.py
+++ b/tests/test_monitor_card_helpers.py
@@ -100,14 +100,15 @@ class TestHdrSliderValues:
         assert spec.maximum == 2000.0
         assert spec.default == 500.0
 
-    def test_auto_default_flag_set_on_all_luminance_fields(self):
+    def test_auto_default_flag_set_for_fields_with_non_hyprland_defaults(self):
         # The auto_default flag drives the config-emission semantic: True means
-        # spec.default is a real value (panel EDID) and gets written to disk
-        # explicitly; False means spec.default is Hyprland's own correct
-        # no-override (the 1.0 default for sdr_brightness/sdr_saturation), so
+        # spec.default is a real value to write to disk explicitly (panel EDID
+        # for luminance, the HDR-mode 0.5 starting point for sdr_brightness);
+        # False means spec.default is Hyprland's own correct no-override, so
         # omit from disk and let hyprland-state's explicit_hdr_defaults=True
         # handle the live-apply reset.
         for field in (
+            "sdr_brightness",
             "sdr_min_luminance",
             "sdr_max_luminance",
             "min_luminance",
@@ -117,9 +118,14 @@ class TestHdrSliderValues:
             spec = HDR_SLIDER_SPEC_BY_FIELD[field]
             assert spec.auto_default is True, f"{field} should auto-default"
 
-        for field in ("sdr_brightness", "sdr_saturation"):
-            spec = HDR_SLIDER_SPEC_BY_FIELD[field]
-            assert spec.auto_default is False, f"{field} should not auto-default"
+        # sdr_saturation is the lone holdout — Hyprland's 1.0 default is the
+        # right value for HDR mode too, so we omit at default.
+        assert HDR_SLIDER_SPEC_BY_FIELD["sdr_saturation"].auto_default is False
+
+    def test_sdr_brightness_hdr_default(self):
+        # sdr_brightness sits at 0.5 in HDR mode, not Hyprland's no-override 1.0
+        # which over-brightens SDR content in the HDR pipeline.
+        assert HDR_SLIDER_SPEC_BY_FIELD["sdr_brightness"].default == 0.5
 
     def test_luminance_fields_present(self):
         for field in (
@@ -161,10 +167,11 @@ class TestResolveHdrSpecs:
         assert specs["max_luminance"].default == 800.0
 
     def test_sdr_brightness_and_saturation_unaffected(self):
-        # Scalar pipeline knobs with 1.0 as the real Hyprland default — never overridden.
+        # Scalar pipeline knobs — defaults are creative/Hyprland constants,
+        # never overridden by EDID.
         caps = {"max_luminance": 993.0, "max_avg_luminance": 277.0, "min_luminance": 0.0006}
         specs = {s.field: s for s in _resolve_hdr_specs(caps)}
-        assert specs["sdr_brightness"].default == SDR_VALUE_DEFAULT
+        assert specs["sdr_brightness"].default == 0.5
         assert specs["sdr_saturation"].default == SDR_VALUE_DEFAULT
 
 

--- a/tests/test_monitor_card_helpers.py
+++ b/tests/test_monitor_card_helpers.py
@@ -1,5 +1,7 @@
 """Unit tests for the pure helpers in monitor card UI (no GTK required)."""
 
+from dataclasses import replace
+
 from hyprmod.pages.monitors.card import (
     CM_MODES,
     CM_VALUES,
@@ -12,6 +14,7 @@ from hyprmod.pages.monitors.card import (
     _format_sdr,
     _parse_hdr_value,
     _parse_sdr,
+    _resolve_hdr_specs,
 )
 
 
@@ -64,15 +67,48 @@ class TestHdrSliderValues:
         assert _parse_hdr_value("250", 80.0) == 250.0
         assert _parse_hdr_value("invalid", -1.0) == -1.0
 
-    def test_format_uses_field_default(self):
+    def test_format_returns_none_at_default_for_non_auto_fields(self):
+        # auto_default=False (sdr_brightness/saturation): omit at default so the
+        # saved config doesn't carry redundant lines for values Hyprland already
+        # uses by default.
         assert _format_hdr_value(80.0, 80.0, 0) is None
         assert _format_hdr_value(120.0, 80.0, 0) == "120"
         assert _format_hdr_value(0.25, 0.2, 2) == "0.25"
+
+    def test_format_always_emits_for_auto_default_fields(self):
+        # auto_default=True (luminance): spec.default is the panel's EDID value;
+        # the config must carry it explicitly because Hyprland's no-override
+        # behavior for these fields is wrong (uses an internal default that
+        # ignores the panel's mastering luminance).
+        assert _format_hdr_value(993.0, 993.0, 0, auto_default=True) == "993"
+        assert _format_hdr_value(800.0, 993.0, 0, auto_default=True) == "800"
+
+    def test_format_rounds_to_slider_precision(self):
+        # Sub-precision panel values like 0.000611 cd/m² collapse to 0 at the
+        # slider's digits=2 representation. That's by design — the difference
+        # is well below human perception and the panel can't display it
+        # distinctly anyway, so the config stays panel-spec-agnostic.
+        assert _format_hdr_value(0.000611, 0.000611, 2, auto_default=True) == "0"
+        # Slider-representable values keep their precision.
+        assert _format_hdr_value(0.5, 0.000611, 2, auto_default=True) == "0.5"
 
     def test_sdr_brightness_display_uses_two_decimals(self):
         spec = HDR_SLIDER_SPEC_BY_FIELD["sdr_brightness"]
         assert _format_hdr_display_value(1.0, spec) == "1.00"
         assert _format_hdr_display_value(1.25, spec) == "1.25"
+
+    def test_display_value_uses_slider_precision(self):
+        # Labels render at the slider's native digits — sub-precision panel
+        # defaults render as "0.00" because that's what the slider represents,
+        # and the imperceptible difference between 0 and 0.000611 cd/m² makes
+        # the precision-loss harmless.
+        min_spec = replace(HDR_SLIDER_SPEC_BY_FIELD["sdr_min_luminance"], default=0.000611)
+        assert _format_hdr_display_value(0.000611, min_spec) == "0.00"
+        assert _format_hdr_display_value(0.5, min_spec) == "0.50"
+
+        max_spec = replace(HDR_SLIDER_SPEC_BY_FIELD["sdr_max_luminance"], default=993.486)
+        assert _format_hdr_display_value(993.486, max_spec) == "993"
+        assert _format_hdr_display_value(990.0, max_spec) == "990"
 
     def test_luminance_ranges_and_defaults(self):
         assert HDR_SLIDER_SPEC_BY_FIELD["min_luminance"].title == "HDR Min Luminance"
@@ -83,21 +119,37 @@ class TestHdrSliderValues:
             assert spec.minimum == 0.0
             assert spec.maximum == 2000.0
             assert spec.default == 800.0
-            assert spec.auto_default is False
 
         for field in ("sdr_min_luminance", "min_luminance"):
             spec = HDR_SLIDER_SPEC_BY_FIELD[field]
             assert spec.minimum == 0.0
             assert spec.maximum == 1.0
-            assert spec.auto_default is False
 
-    def test_max_avg_defaults_to_auto_without_negative_range(self):
         spec = HDR_SLIDER_SPEC_BY_FIELD["max_avg_luminance"]
         assert spec.minimum == 0.0
         assert spec.maximum == 2000.0
         assert spec.default == 500.0
-        assert spec.auto_default is True
-        assert _format_hdr_display_value(spec.default, spec) == "Auto"
+
+    def test_auto_default_flag_set_on_all_luminance_fields(self):
+        # The auto_default flag drives the config-emission semantic: True means
+        # spec.default is a real value (panel EDID) and gets written to disk
+        # explicitly; False means spec.default is Hyprland's own correct
+        # no-override (the 1.0 default for sdr_brightness/sdr_saturation), so
+        # omit from disk and let hyprland-state's explicit_hdr_defaults=True
+        # handle the live-apply reset.
+        for field in (
+            "sdr_min_luminance",
+            "sdr_max_luminance",
+            "min_luminance",
+            "max_luminance",
+            "max_avg_luminance",
+        ):
+            spec = HDR_SLIDER_SPEC_BY_FIELD[field]
+            assert spec.auto_default is True, f"{field} should auto-default"
+
+        for field in ("sdr_brightness", "sdr_saturation"):
+            spec = HDR_SLIDER_SPEC_BY_FIELD[field]
+            assert spec.auto_default is False, f"{field} should not auto-default"
 
     def test_luminance_fields_present(self):
         for field in (
@@ -111,6 +163,42 @@ class TestHdrSliderValues:
 
     def test_reset_fields_cover_all_hdr_sliders(self):
         assert HDR_RESET_FIELDS == HDR_SLIDER_FIELDS
+
+
+class TestResolveHdrSpecs:
+    def test_caps_override_auto_position_with_edid_value(self):
+        # A real-panel example: 993 cd/m² peak, 277 cd/m² average, 0.0006 cd/m² min.
+        # Both SDR and HDR variants of min/max share the same EDID source.
+        caps = {
+            "max_luminance": 993.0,
+            "max_avg_luminance": 277.0,
+            "min_luminance": 0.0006,
+        }
+        specs = {s.field: s for s in _resolve_hdr_specs(caps)}
+        assert specs["sdr_max_luminance"].default == 993.0
+        assert specs["max_luminance"].default == 993.0
+        assert specs["max_avg_luminance"].default == 277.0
+        assert specs["sdr_min_luminance"].default == 0.0006
+        assert specs["min_luminance"].default == 0.0006
+
+    def test_falls_back_to_template_when_caps_missing(self):
+        # No EDID coverage at all (typical for non-HDR monitors).
+        specs = {s.field: s for s in _resolve_hdr_specs({})}
+        assert specs["sdr_max_luminance"].default == 800.0
+        assert specs["max_avg_luminance"].default == 500.0
+
+    def test_falls_back_when_caps_value_is_none(self):
+        # Caps dict includes the key but EDID didn't carry a value — still falls back.
+        caps = {"max_luminance": None, "max_avg_luminance": None, "min_luminance": None}
+        specs = {s.field: s for s in _resolve_hdr_specs(caps)}
+        assert specs["max_luminance"].default == 800.0
+
+    def test_sdr_brightness_and_saturation_unaffected(self):
+        # Scalar pipeline knobs with 1.0 as the real Hyprland default — never overridden.
+        caps = {"max_luminance": 993.0, "max_avg_luminance": 277.0, "min_luminance": 0.0006}
+        specs = {s.field: s for s in _resolve_hdr_specs(caps)}
+        assert specs["sdr_brightness"].default == SDR_VALUE_DEFAULT
+        assert specs["sdr_saturation"].default == SDR_VALUE_DEFAULT
 
 
 class TestColorManagementPresets:

--- a/tests/test_monitor_card_helpers.py
+++ b/tests/test_monitor_card_helpers.py
@@ -3,8 +3,14 @@
 from hyprmod.pages.monitors.card import (
     CM_MODES,
     CM_VALUES,
+    HDR_RESET_FIELDS,
+    HDR_SLIDER_FIELDS,
+    HDR_SLIDER_SPEC_BY_FIELD,
     SDR_VALUE_DEFAULT,
+    _format_hdr_display_value,
+    _format_hdr_value,
     _format_sdr,
+    _parse_hdr_value,
     _parse_sdr,
 )
 
@@ -50,6 +56,61 @@ class TestFormatSdr:
         # Regression: naive rstrip("0").rstrip(".") would produce "" for 0.0,
         # which then got written as a malformed config line.
         assert _format_sdr(0.0) == "0"
+
+
+class TestHdrSliderValues:
+    def test_parse_uses_field_default(self):
+        assert _parse_hdr_value(None, 80.0) == 80.0
+        assert _parse_hdr_value("250", 80.0) == 250.0
+        assert _parse_hdr_value("invalid", -1.0) == -1.0
+
+    def test_format_uses_field_default(self):
+        assert _format_hdr_value(80.0, 80.0, 0) is None
+        assert _format_hdr_value(120.0, 80.0, 0) == "120"
+        assert _format_hdr_value(0.25, 0.2, 2) == "0.25"
+
+    def test_sdr_brightness_display_uses_two_decimals(self):
+        spec = HDR_SLIDER_SPEC_BY_FIELD["sdr_brightness"]
+        assert _format_hdr_display_value(1.0, spec) == "1.00"
+        assert _format_hdr_display_value(1.25, spec) == "1.25"
+
+    def test_luminance_ranges_and_defaults(self):
+        assert HDR_SLIDER_SPEC_BY_FIELD["min_luminance"].title == "HDR Min Luminance"
+        assert HDR_SLIDER_SPEC_BY_FIELD["max_luminance"].title == "HDR Max Luminance"
+
+        for field in ("sdr_max_luminance", "max_luminance"):
+            spec = HDR_SLIDER_SPEC_BY_FIELD[field]
+            assert spec.minimum == 0.0
+            assert spec.maximum == 2000.0
+            assert spec.default == 800.0
+            assert spec.auto_default is False
+
+        for field in ("sdr_min_luminance", "min_luminance"):
+            spec = HDR_SLIDER_SPEC_BY_FIELD[field]
+            assert spec.minimum == 0.0
+            assert spec.maximum == 1.0
+            assert spec.auto_default is False
+
+    def test_max_avg_defaults_to_auto_without_negative_range(self):
+        spec = HDR_SLIDER_SPEC_BY_FIELD["max_avg_luminance"]
+        assert spec.minimum == 0.0
+        assert spec.maximum == 2000.0
+        assert spec.default == 500.0
+        assert spec.auto_default is True
+        assert _format_hdr_display_value(spec.default, spec) == "Auto"
+
+    def test_luminance_fields_present(self):
+        for field in (
+            "sdr_min_luminance",
+            "sdr_max_luminance",
+            "min_luminance",
+            "max_luminance",
+            "max_avg_luminance",
+        ):
+            assert field in HDR_SLIDER_FIELDS
+
+    def test_reset_fields_cover_all_hdr_sliders(self):
+        assert HDR_RESET_FIELDS == HDR_SLIDER_FIELDS
 
 
 class TestColorManagementPresets:

--- a/tests/test_monitors_page.py
+++ b/tests/test_monitors_page.py
@@ -5,6 +5,7 @@ from unittest.mock import MagicMock
 
 import pytest
 from hyprland_monitors import MonitorState
+from hyprland_monitors.monitors import lines_from_monitors
 
 from hyprmod.core import config
 from hyprmod.pages.monitors.page import MonitorsPage
@@ -112,3 +113,22 @@ class TestDescIdentifierResolution:
         assert page._ownership.is_owned("HDMI-A-1")
         # The toggle is restored from the saved line.
         assert page._monitors[0].identify_by_description is True
+
+
+class TestHdrExtras:
+    def test_new_luminance_fields_round_trip(self, page_with_monitors):
+        page = page_with_monitors(
+            "monitor = DP-1, 1920x1080@60.00Hz, 0x0, 1, "
+            "cm, hdr, sdr_min_luminance, 0.3, sdr_max_luminance, 120, "
+            "min_luminance, 0.01, max_luminance, 1000, max_avg_luminance, 400\n",
+            [[_make_monitor("DP-1", "Acme Pixel 5000")]],
+        )
+
+        mon = page._monitors[0]
+        assert mon.sdr_min_luminance == "0.3"
+        assert mon.sdr_max_luminance == "120"
+        assert mon.min_luminance == "0.01"
+        assert mon.max_luminance == "1000"
+        assert mon.max_avg_luminance == "400"
+        assert page.is_dirty() is False
+        assert "sdr_min_luminance, 0.3" in lines_from_monitors([mon])[0]

--- a/uv.lock
+++ b/uv.lock
@@ -22,14 +22,14 @@ wheels = [
 
 [[package]]
 name = "hyprland-monitors"
-version = "0.6.0"
+version = "0.7.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "hyprland-socket" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/82/9b/50f32120a04f097960ea076cfa19ebbd8e31b7637e0aba947ee458c13b50/hyprland_monitors-0.6.0.tar.gz", hash = "sha256:116e48fcee08d3d3befa3347d136c5bcb1d3acd002a8a96fe0332957e33fd8e4", size = 11287, upload-time = "2026-05-17T16:10:17.023Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/80/6f/f8e4a584628c66e0c47cf8d8496f131f0bcb09ce958bf66ada0cb26960e1/hyprland_monitors-0.7.0.tar.gz", hash = "sha256:08b6d881b5d99b865288568ae77a9422eb2ab657f86a939bfc438d66fa70dd14", size = 12559, upload-time = "2026-05-19T08:17:46.257Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/a7/27/2395546e23a60c463b21724ba07cbc3fc3654f0302151a5eab786d516527/hyprland_monitors-0.6.0-py3-none-any.whl", hash = "sha256:b0ffe2ba5315c3ae2454e75d6e4ffe7a33d773f34ba987583fad493021d605a1", size = 12900, upload-time = "2026-05-17T16:10:15.361Z" },
+    { url = "https://files.pythonhosted.org/packages/eb/90/e8bf501da506a8adf906a2dcffe1d039381d6b4c0d1e1da45a4e021e4a9c/hyprland_monitors-0.7.0-py3-none-any.whl", hash = "sha256:0c375a0b9e04041ce52d6e6dd8d54f0fe9fcea78ae762904e0df5ae4904e04cc", size = 14235, upload-time = "2026-05-19T08:17:44.731Z" },
 ]
 
 [[package]]
@@ -89,7 +89,7 @@ dev = [
 [package.metadata]
 requires-dist = [
     { name = "hyprland-config", specifier = ">=0.6.5" },
-    { name = "hyprland-monitors", specifier = ">=0.6.0" },
+    { name = "hyprland-monitors", specifier = ">=0.7.0" },
     { name = "hyprland-schema", specifier = ">=0.6.1" },
     { name = "hyprland-socket", specifier = ">=0.12.1" },
     { name = "hyprland-state", specifier = ">=0.4.1" },


### PR DESCRIPTION
Adds advanced per-monitor HDR controls for:

  - SDR brightness and saturation
  - SDR min/max luminance
  - HDR min/max luminance
  - Max average luminance

  The HDR/SDR max luminance values should be set according to the monitor’s real peak brightness in nits from its specifications. A Safe Defaults action initializes conservative values, and linked SDR/HDR luminance controls can be locked to adjust together. The PR also preserves these fields in generated monitor = ... lines and initializes missing HDR defaults when enabling HDR for the first time.

fixes https://github.com/BlueManCZ/hyprmod/issues/29

  AI disclaimer:
  This PR was generated with assistance from AI.