### PR TITLE
Fix re-enabling disabled monitors and post-reboot 0x0 handling

### DIFF
--- a/hyprmod/pages/monitors/card.py
+++ b/hyprmod/pages/monitors/card.py
@@ -6,6 +6,7 @@ from gi.repository import Adw, Gtk
 from hyprland_monitors.monitors import (
     TRANSFORMS,
     MonitorState,
+    ScaleOption,
     compute_valid_scales,
     nearest_scale_index,
     parse_mode,
@@ -372,6 +373,8 @@ class MonitorCard(Gtk.Box):
 
         w, h = monitor.width, monitor.height
         self._valid_scales = compute_valid_scales(w, h)
+        if not self._valid_scales:
+            self._valid_scales = [ScaleOption(1.00, "1.00")]
         scale_labels = [label for _, label in self._valid_scales]
         self._scale_row = Adw.ComboRow(
             title="Scale",
@@ -785,10 +788,13 @@ class MonitorCard(Gtk.Box):
             self._pos_y.set_value(mon.y)
 
             new_scales = compute_valid_scales(mon.width, mon.height)
-            if new_scales != self._valid_scales:
-                self._valid_scales = new_scales
-                self._scale_row.set_model(Gtk.StringList.new([label for _, label in new_scales]))
-            self._scale_row.set_selected(nearest_scale_index(self._valid_scales, mon.scale))
+            if new_scales:
+                if new_scales != self._valid_scales:
+                    self._valid_scales = new_scales
+                    self._scale_row.set_model(
+                        Gtk.StringList.new([label for _, label in new_scales])
+                    )
+                self._scale_row.set_selected(nearest_scale_index(self._valid_scales, mon.scale))
             self._transform_row.set_selected(mon.transform)
 
             if self._bitdepth_row:

--- a/hyprmod/pages/monitors/page.py
+++ b/hyprmod/pages/monitors/page.py
@@ -166,6 +166,39 @@ class MonitorsPage(SectionPage):
         saved = config.collect_section(sections, config.KEYWORD_MONITOR)
         if saved:
             merge_saved_state(self._monitors, saved)
+
+            live_names = {m.name for m in self._monitors}
+            for line in saved:
+                port = self._resolve_line_to_port(line)
+                if port and port not in live_names:
+                    is_line_disabled = "disabled" in line.lower() or "none" in line.lower()
+
+                    if is_line_disabled:
+                        # If it's unplugged AND disabled, skip creating a mock object.
+                        # This marks it for removal from the configuration on the next save/commit.
+                        continue
+
+                    # Create a mock MonitorState object for the missing/disabled display
+                    disabled_mon = MonitorState(
+                        name=port,
+                        make="",
+                        model="Disabled Display",
+                        width=0,
+                        height=0,
+                        refresh_rate=0.0,
+                        x=0,
+                        y=0,
+                        scale=1.0,
+                    )
+                    disabled_mon.disabled = True
+
+                    # Append the mock so the UI registers the "Disabled Display" with a card
+                    self._monitors.append(disabled_mon)
+                    live_names.add(port)
+
+            # Sort to maintain clean order in the UI layout
+            self._monitors.sort(key=lambda m: m.name)
+
         self._ownership = OwnershipSet(self._managed_names_from_lines(saved))
         # Since monitor= is all-or-nothing, our line replaces the user's
         # entire line.  IPC may still report extras from the user's config
@@ -748,6 +781,13 @@ class MonitorsPage(SectionPage):
             self._confirm.cancel()
         if self._content_box is not None:
             self._update_card_states()
+
+        try:
+            self._window.hypr.monitors._state.reload_compositor()
+        except Exception as e:
+            # Fallback wrapper tracking in case of unexpected socket bubbles
+            if hasattr(self._window, "show_toast"):
+                self._window.show_toast(f"Compositor reload notification failed: {e}")
 
     def discard(self):
         if not self._saved_monitors or not self.is_dirty():

--- a/hyprmod/pages/monitors/page.py
+++ b/hyprmod/pages/monitors/page.py
@@ -480,6 +480,30 @@ class MonitorsPage(SectionPage):
         self._on_monitors_changed()
         self._schedule_resync()
 
+    def _commit_to_hyprland(self):
+        """Send all monitors to Hyprland, push to UI."""
+        self._applying = True
+        try:
+            success = try_with_toast(
+                self._window.show_bug_toast,
+                "Monitor config failed",
+                lambda: self._window.hypr.monitors.apply(self._monitors),
+                catch=HyprlandError,
+            )
+
+            if success:
+                # Always synchronize live coordinates/scales directly from hardware.
+                self._sync_dimensions_from_hardware()
+                self._push_to_ui()
+
+                # Notify the state tracking system that updates occurred
+                # (e.g., triggers confirm banner)
+                self._on_monitors_changed()
+                self._schedule_resync()
+
+        finally:
+            self._applying = False
+
     def _discard_monitor(self, mon: MonitorState):
         """Revert a single monitor to its saved state."""
         saved_by_name = {m.name: m for m in self._saved_monitors}
@@ -491,12 +515,14 @@ class MonitorsPage(SectionPage):
             for field in self._RESTORABLE_FIELDS:
                 setattr(mon, field, getattr(baseline, field))
             self._ownership.discard(mon.name)
+            self._commit_to_hyprland()
 
     def _remove_monitor(self, mon: MonitorState):
         """Remove a monitor from HyprMod management."""
         with self._undo_track():
             self._ownership.disown(mon.name)
             self._apply_monitor_fallback(mon)
+            self._commit_to_hyprland()
 
     def _apply_monitor_fallback(self, mon: MonitorState):
         """Revert a monitor to user-config values (excluding HyprMod).
@@ -585,26 +611,10 @@ class MonitorsPage(SectionPage):
             mon = self._monitors[idx]
             self._ownership.own(mon.name)
 
-            # Commit the final dragged position to Hyprland
-            self._applying = True
-            try:
-                mon.position = None  # Clear keywords (like "auto") to lock hard coordinates
-
-                success = try_with_toast(
-                    self._window.show_bug_toast,
-                    "Monitor layout failed",
-                    lambda: self._window.hypr.monitors.apply(self._monitors),
-                    catch=HyprlandError,
-                )
-                if success:
-                    self._sync_dimensions_from_hardware()
-                    self._push_to_ui()
-            finally:
-                self._applying = False
-
-            # Notify the UI that changes happened (triggers the confirm banner)
-            self._on_monitors_changed()
-            self._schedule_resync()
+            # Clear positional keywords (like "auto") so that
+            # Hyprland respects the explicit numeric x,y coordinates from the drag.
+            mon.position = None
+            self._commit_to_hyprland()
 
         if self._drag_undo_state is not None:
             self._push_undo_from(self._drag_undo_state)

--- a/hyprmod/pages/monitors/page.py
+++ b/hyprmod/pages/monitors/page.py
@@ -143,7 +143,7 @@ class MonitorsPage(SectionPage):
                 for field in self._RESTORABLE_FIELDS:
                     setattr(mon, field, getattr(saved, field))
         self._ownership.restore(owned_names)
-        self._push_to_ui()
+        self._commit_to_hyprland()
 
     # -- Data loading --
 
@@ -187,10 +187,7 @@ class MonitorsPage(SectionPage):
         mon = resolve_identifier(token, self._monitors)
         if mon:
             return mon.name
-
-        # Fallback: If the monitor is disabled or unplugged, it won't be in active self._monitors.
-        # If it's identified directly by its port name, we can safely use the token as-is.
-        return token if not token.startswith("desc:") else None
+        return None
 
     def _clear_unmanaged_extras(self, saved_lines: list[str]):
         """Clear IPC-leaked extras on managed monitors not in our config."""
@@ -473,7 +470,6 @@ class MonitorsPage(SectionPage):
                     return
 
                 # Push safe UI state
-                self._sync_dimensions_from_hardware()
                 self._push_to_ui()
             finally:
                 self._applying = False
@@ -492,8 +488,6 @@ class MonitorsPage(SectionPage):
             )
 
             if success:
-                # Always synchronize live coordinates/scales directly from hardware.
-                self._sync_dimensions_from_hardware()
                 self._push_to_ui()
 
                 # Notify the state tracking system that updates occurred
@@ -579,7 +573,26 @@ class MonitorsPage(SectionPage):
         self._resync_timer.schedule(200, self._deferred_resync)
 
     def _deferred_resync(self):
-        self._sync_dimensions_from_hardware()
+        old_managed = [m for m in self._monitors if self._ownership.is_owned(m.name)]
+        old_lines = sorted(lines_from_monitors(old_managed))
+
+        # Retrieve live dimensions directly from hardware with error handling
+
+        actual = self._window.hypr.monitors.get_all()
+        if actual:
+            actual_by_name = {m.name: m for m in actual if not m.disabled}
+            for mon in self._monitors:
+                hw_mon = actual_by_name.get(mon.name)
+                if not hw_mon:
+                    continue
+
+                # MonitorState and Monitor share the geometry fields used here;
+                # update_geometry_from_ipc declares Monitor but tolerates either.
+                mon.update_geometry_from_ipc(hw_mon)  # type: ignore[arg-type]
+                vs = compute_valid_scales(mon.width, mon.height)
+                if vs:
+                    si = nearest_scale_index(vs, hw_mon.scale)
+                    mon.scale = vs[si][0]
 
         self._applying = True
         try:
@@ -587,7 +600,12 @@ class MonitorsPage(SectionPage):
         finally:
             self._applying = False
 
-        self._on_monitors_changed()
+        # 4. Only trigger change events if the geometry actually moved
+        new_managed = [m for m in self._monitors if self._ownership.is_owned(m.name)]
+        new_lines = sorted(lines_from_monitors(new_managed))
+
+        if new_lines != old_lines:
+            self._on_monitors_changed()
 
     # -- Preview drag --
 
@@ -787,13 +805,6 @@ class MonitorsPage(SectionPage):
         if self._content_box is not None:
             self._update_card_states()
 
-        try:
-            self._window.hypr.monitors._state.reload_compositor()
-        except Exception as e:
-            # Fallback wrapper tracking in case of unexpected socket bubbles
-            if hasattr(self._window, "show_toast"):
-                self._window.show_toast(f"Compositor reload notification failed: {e}")
-
     def discard(self):
         if not self._saved_monitors or not self.is_dirty():
             return
@@ -853,33 +864,3 @@ class MonitorsPage(SectionPage):
     def get_monitor_lines(self) -> list[str]:
         managed = [m for m in self._monitors if self._ownership.is_owned(m.name)]
         return [f"monitor = {line}" for line in lines_from_monitors(managed)]
-
-    def _sync_dimensions_from_hardware(self) -> None:
-        """Query live hardware state to update dimensions, positions, and scales."""
-        try:
-            actual = self._window.hypr.monitors.get_all()
-            if not actual:
-                return
-
-            actual_by_name = {m.name: m for m in actual}
-            for mon in self._monitors:
-                if mon.disabled:
-                    continue
-
-                real = actual_by_name.get(mon.name)
-                if not real:
-                    continue
-
-                # Automatically updates x, y, width, height, and refresh_rate
-                mon.update_geometry_from_ipc(real)  # type: ignore[arg-type]
-
-                # Update scales
-                vs = compute_valid_scales(mon.width, mon.height)
-                if vs:
-                    si = nearest_scale_index(vs, real.scale)
-                    mon.scale = vs[si][0]
-
-        except Exception as e:
-            self._window.show_bug_toast(
-                f"Failed to sync dimension data from hardware — {e}", detail=str(e), timeout=5
-            )

--- a/hyprmod/pages/monitors/page.py
+++ b/hyprmod/pages/monitors/page.py
@@ -1,18 +1,16 @@
 """Monitor management page — orchestrates cards, preview, and Hyprland IPC."""
 
 import copy
-import json
-import re
-import subprocess
 from collections.abc import Iterator
 
-from gi.repository import Adw, GLib, Gtk
+from gi.repository import Adw, Gtk
 from hyprland_monitors import get_monitor_capabilities
 from hyprland_monitors.monitors import (
     MonitorState,
     adjust_neighbors,
     all_monitors_connected,
     compute_valid_scales,
+    is_adjacent,
     lines_from_monitors,
     merge_saved_state,
     nearest_scale_index,
@@ -146,7 +144,6 @@ class MonitorsPage(SectionPage):
                     setattr(mon, field, getattr(saved, field))
         self._ownership.restore(owned_names)
         self._push_to_ui()
-        self._commit_to_hyprland()
 
     # -- Data loading --
 
@@ -169,44 +166,6 @@ class MonitorsPage(SectionPage):
         saved = config.collect_section(sections, config.KEYWORD_MONITOR)
         if saved:
             merge_saved_state(self._monitors, saved)
-
-            # Extract hardware names to identify disabled-but-physically-plugged monitors
-            hardware_monitors = self._fetch_hardware_monitors()
-            hardware_names = {
-                str(h.get("name")) for h in hardware_monitors if isinstance(h.get("name"), str)
-            }
-
-            live_names = {m.name for m in self._monitors}
-            for line in saved:
-                port = self._resolve_line_to_port(line)
-                if port and port not in live_names:
-                    is_line_disabled = "disabled" in line.lower() or "none" in line.lower()
-
-                    if is_line_disabled:
-                        # Only skip creating a mock object if it is completely unplugged (absent from hardware)
-                        if hardware_names and port not in hardware_names:
-                            continue
-
-                    # Create a mock MonitorState object for the missing/disabled display
-                    disabled_mon = MonitorState(
-                        name=port,
-                        make="",
-                        model="Disabled Display",
-                        width=640,
-                        height=480,
-                        refresh_rate=30.0,
-                        x=0,
-                        y=0,
-                        scale=1.0,
-                    )
-                    disabled_mon.disabled = True
-
-                    # Append the mock so the UI registers the "Disabled Display" with a card
-                    self._monitors.append(disabled_mon)
-                    live_names.add(port)
-
-            # Sort to maintain clean order in the UI layout
-            self._monitors.sort(key=lambda m: m.name)
 
         self._ownership = OwnershipSet(self._managed_names_from_lines(saved))
         # Since monitor= is all-or-nothing, our line replaces the user's
@@ -252,7 +211,14 @@ class MonitorsPage(SectionPage):
     def _snap_scales(self):
         """Map 2dp scales from Hyprland to full-precision 1/120 values."""
         for mon in self._monitors:
+            # Skip disabled or unconfigured monitors from IPC that have 0 width/height
+            if mon.disabled or mon.width == 0 or mon.height == 0:
+                continue
+
             vs = compute_valid_scales(mon.width, mon.height)
+            if not vs:
+                continue
+
             si = nearest_scale_index(vs, mon.scale)
             mon.scale = vs[si][0]
 
@@ -461,80 +427,19 @@ class MonitorsPage(SectionPage):
                 old_w, old_h = mon.effective_size
 
                 # Detect if the display is transitioning from disabled to enabled
-                is_being_enabled = "disabled" in new_vals and not new_vals["disabled"]
+                is_being_enabled = mon.disabled and not new_vals.get("disabled", mon.disabled)
 
                 for k, v in new_vals.items():
                     setattr(mon, k, v)
 
-                if is_being_enabled:
-                    # Query the global hardware list via our helper method
-                    try:
-                        all_hardware = self._fetch_hardware_monitors()
+                # Clear special keywords if explicit resolution/positioning changes are targeted
+                if not is_being_enabled:
+                    if "width" in new_vals or "height" in new_vals or "refresh_rate" in new_vals:
+                        mon.mode = None
+                    if "x" in new_vals or "y" in new_vals:
+                        mon.position = None
 
-                        # Locate the hardware block matching this monitor's connector name
-                        hw_match = next(
-                            (
-                                h
-                                for h in all_hardware
-                                if isinstance(h.get("name"), str) and h["name"] == mon.name
-                            ),
-                            None,
-                        )
-                        if hw_match:
-                            modes = hw_match.get("availableModes")
-                            if isinstance(modes, list) and len(modes) > 0:
-                                # Parse the first (preferred/native) resolution mode
-                                first_mode = str(modes[0]).strip().replace("Hz", "")
-                                match = re.match(r"(\d+)x(\d+)(?:@([\d.]+))?", first_mode)
-                                if match:
-                                    mon.width = int(match.group(1))
-                                    mon.height = int(match.group(2))
-                                    mon.refresh_rate = (
-                                        float(match.group(3)) if match.group(3) else 60.0
-                                    )
-                    except Exception as hardware_error:
-                        self._window.show_toast(
-                            "Error finding available modes "
-                            + f"for re-enabled display: {hardware_error}",
-                            timeout=3,
-                            copy=True,
-                        )
-
-                    # Conditional Snapping: Check if enabling this monitor leaves a layout gap or causes an overlap
-                    active_others = [
-                        m
-                        for m in self._monitors
-                        if m.name != mon.name and not m.disabled and not m.mirror_of
-                    ]
-
-                    # Detect spatial collision/overlap with any currently active monitors
-                    has_overlap = False
-                    mw, mh = mon.effective_size
-                    for other in active_others:
-                        ow, oh = other.effective_size
-                        if (
-                            mon.x < other.x + ow
-                            and mon.x + mw > other.x
-                            and mon.y < other.y + oh
-                            and mon.y + mh > other.y
-                        ):
-                            has_overlap = True
-                            break
-
-                    # Snap to the right if there's an overlap or a gap in overall layout connectivity
-                    if has_overlap or not all_monitors_connected(self._monitors):
-                        if active_others:
-                            # Position it instantly adjacent to the far-right edge of the active layout
-                            mon.x = max(m.x + m.effective_size[0] for m in active_others)
-                            mon.y = 0
-                        # Align edges cleanly using a 0x0 baseline context
-                        adjust_neighbors(self._monitors, mon, 0, 0)
-
-                elif "width" in new_vals or "height" in new_vals:
-                    vs = compute_valid_scales(mon.width, mon.height)
-                    si = nearest_scale_index(vs, mon.scale)
-                    mon.scale = vs[si][0]
-
+                # Calculate side-effects (neighbor offsets / breaking mirror lines)
                 if (
                     not is_being_enabled
                     and "disabled" not in new_vals
@@ -549,13 +454,26 @@ class MonitorsPage(SectionPage):
                             other.mirror_of = None
                             self._ownership.own(other.name)
 
-                if not try_with_toast(
+                if is_being_enabled:
+                    has_active_neighbor = any(
+                        is_adjacent(mon, other)
+                        for other in self._monitors
+                        if other.name != mon.name and not other.disabled
+                    )
+                    if not has_active_neighbor:
+                        mon.position = "auto"
+
+                success = try_with_toast(
                     self._window.show_bug_toast,
                     "Monitor config failed",
                     lambda: self._window.hypr.monitors.apply(self._monitors),
                     catch=HyprlandError,
-                ):
+                )
+                if not success:
                     return
+
+                # Push safe UI state
+                self._sync_dimensions_from_hardware()
                 self._push_to_ui()
             finally:
                 self._applying = False
@@ -573,14 +491,12 @@ class MonitorsPage(SectionPage):
             for field in self._RESTORABLE_FIELDS:
                 setattr(mon, field, getattr(baseline, field))
             self._ownership.discard(mon.name)
-            self._commit_to_hyprland()
 
     def _remove_monitor(self, mon: MonitorState):
         """Remove a monitor from HyprMod management."""
         with self._undo_track():
             self._ownership.disown(mon.name)
             self._apply_monitor_fallback(mon)
-            self._commit_to_hyprland()
 
     def _apply_monitor_fallback(self, mon: MonitorState):
         """Revert a monitor to user-config values (excluding HyprMod).
@@ -637,33 +553,15 @@ class MonitorsPage(SectionPage):
         self._resync_timer.schedule(200, self._deferred_resync)
 
     def _deferred_resync(self):
-        old_lines = lines_from_monitors(self._monitors)
-        actual = self._window.hypr.monitors.get_all()
-        if not actual:
-            return GLib.SOURCE_REMOVE
+        self._sync_dimensions_from_hardware()
 
-        actual_by_name = {m.name: m for m in actual}
-        for mon in self._monitors:
-            if mon.disabled:
-                continue
-            real = actual_by_name.get(mon.name)
-            if not real:
-                continue
-            # MonitorState and Monitor share the geometry fields used here;
-            # update_geometry_from_ipc declares Monitor but tolerates either.
-            mon.update_geometry_from_ipc(real)  # type: ignore[arg-type]
-            vs = compute_valid_scales(mon.width, mon.height)
-            si = nearest_scale_index(vs, real.scale)
-            mon.scale = vs[si][0]
+        self._applying = True
+        try:
+            self._push_to_ui()
+        finally:
+            self._applying = False
 
-        if lines_from_monitors(self._monitors) != old_lines:
-            self._applying = True
-            try:
-                self._push_to_ui()
-            finally:
-                self._applying = False
-            self._on_monitors_changed()
-        return GLib.SOURCE_REMOVE
+        self._on_monitors_changed()
 
     # -- Preview drag --
 
@@ -682,9 +580,32 @@ class MonitorsPage(SectionPage):
     def _on_preview_drag_end(self):
         idx = self._last_dragged_idx
         self._last_dragged_idx = -1
+
         if 0 <= idx < len(self._monitors):
-            self._ownership.own(self._monitors[idx].name)
-        self._commit_to_hyprland()
+            mon = self._monitors[idx]
+            self._ownership.own(mon.name)
+
+            # Commit the final dragged position to Hyprland
+            self._applying = True
+            try:
+                mon.position = None  # Clear keywords (like "auto") to lock hard coordinates
+
+                success = try_with_toast(
+                    self._window.show_bug_toast,
+                    "Monitor layout failed",
+                    lambda: self._window.hypr.monitors.apply(self._monitors),
+                    catch=HyprlandError,
+                )
+                if success:
+                    self._sync_dimensions_from_hardware()
+                    self._push_to_ui()
+            finally:
+                self._applying = False
+
+            # Notify the UI that changes happened (triggers the confirm banner)
+            self._on_monitors_changed()
+            self._schedule_resync()
+
         if self._drag_undo_state is not None:
             self._push_undo_from(self._drag_undo_state)
             self._drag_undo_state = None
@@ -923,19 +844,32 @@ class MonitorsPage(SectionPage):
         managed = [m for m in self._monitors if self._ownership.is_owned(m.name)]
         return [f"monitor = {line}" for line in lines_from_monitors(managed)]
 
-    def _fetch_hardware_monitors(self) -> list[dict[str, object]]:
-        """Query the global hardware list of all connected monitors from Hyprland IPC."""
-        result: list[dict[str, object]] = []
+    def _sync_dimensions_from_hardware(self) -> None:
+        """Query live hardware state to update dimensions, positions, and scales."""
         try:
-            # TODO 02/06/26 - self._window.hypr.monitors.get_all() should do this, but does not.
-            # Should update hyprland-state &| hyprland-socket with a function of either
-            # `hyprctl monitors` and `hyprctl monitors all`
-            output = subprocess.check_output(["hyprctl", "monitors", "all", "-j"], text=True)
-            data = json.loads(output)
-            if isinstance(data, list):
-                result = data
+            actual = self._window.hypr.monitors.get_all()
+            if not actual:
+                return
+
+            actual_by_name = {m.name: m for m in actual}
+            for mon in self._monitors:
+                if mon.disabled:
+                    continue
+
+                real = actual_by_name.get(mon.name)
+                if not real:
+                    continue
+
+                # Automatically updates x, y, width, height, and refresh_rate
+                mon.update_geometry_from_ipc(real)  # type: ignore[arg-type]
+
+                # Update scales
+                vs = compute_valid_scales(mon.width, mon.height)
+                if vs:
+                    si = nearest_scale_index(vs, real.scale)
+                    mon.scale = vs[si][0]
+
         except Exception as e:
             self._window.show_bug_toast(
-                f"Hyprctl monitors all -j failed — {e}", detail=str(e), timeout=5
+                f"Failed to sync dimension data from hardware — {e}", detail=str(e), timeout=5
             )
-        return result

--- a/hyprmod/pages/monitors/page.py
+++ b/hyprmod/pages/monitors/page.py
@@ -1,6 +1,9 @@
 """Monitor management page — orchestrates cards, preview, and Hyprland IPC."""
 
 import copy
+import json
+import re
+import subprocess
 from collections.abc import Iterator
 
 from gi.repository import Adw, GLib, Gtk
@@ -167,6 +170,12 @@ class MonitorsPage(SectionPage):
         if saved:
             merge_saved_state(self._monitors, saved)
 
+            # Extract hardware names to identify disabled-but-physically-plugged monitors
+            hardware_monitors = self._fetch_hardware_monitors()
+            hardware_names = {
+                str(h.get("name")) for h in hardware_monitors if isinstance(h.get("name"), str)
+            }
+
             live_names = {m.name for m in self._monitors}
             for line in saved:
                 port = self._resolve_line_to_port(line)
@@ -174,18 +183,18 @@ class MonitorsPage(SectionPage):
                     is_line_disabled = "disabled" in line.lower() or "none" in line.lower()
 
                     if is_line_disabled:
-                        # If it's unplugged AND disabled, skip creating a mock object.
-                        # This marks it for removal from the configuration on the next save/commit.
-                        continue
+                        # Only skip creating a mock object if it is completely unplugged (absent from hardware)
+                        if hardware_names and port not in hardware_names:
+                            continue
 
                     # Create a mock MonitorState object for the missing/disabled display
                     disabled_mon = MonitorState(
                         name=port,
                         make="",
                         model="Disabled Display",
-                        width=0,
-                        height=0,
-                        refresh_rate=0.0,
+                        width=640,
+                        height=480,
+                        refresh_rate=30.0,
                         x=0,
                         y=0,
                         scale=1.0,
@@ -217,7 +226,12 @@ class MonitorsPage(SectionPage):
         if not token:
             return None
         mon = resolve_identifier(token, self._monitors)
-        return mon.name if mon else None
+        if mon:
+            return mon.name
+
+        # Fallback: If the monitor is disabled or unplugged, it won't be in active self._monitors.
+        # If it's identified directly by its port name, we can safely use the token as-is.
+        return token if not token.startswith("desc:") else None
 
     def _clear_unmanaged_extras(self, saved_lines: list[str]):
         """Clear IPC-leaked extras on managed monitors not in our config."""
@@ -445,20 +459,96 @@ class MonitorsPage(SectionPage):
             self._applying = True
             try:
                 old_w, old_h = mon.effective_size
+
+                # Detect if the display is transitioning from disabled to enabled
+                is_being_enabled = "disabled" in new_vals and not new_vals["disabled"]
+
                 for k, v in new_vals.items():
                     setattr(mon, k, v)
-                if "width" in new_vals or "height" in new_vals:
+
+                if is_being_enabled:
+                    # Query the global hardware list via our helper method
+                    try:
+                        all_hardware = self._fetch_hardware_monitors()
+
+                        # Locate the hardware block matching this monitor's connector name
+                        hw_match = next(
+                            (
+                                h
+                                for h in all_hardware
+                                if isinstance(h.get("name"), str) and h["name"] == mon.name
+                            ),
+                            None,
+                        )
+                        if hw_match:
+                            modes = hw_match.get("availableModes")
+                            if isinstance(modes, list) and len(modes) > 0:
+                                # Parse the first (preferred/native) resolution mode
+                                first_mode = str(modes[0]).strip().replace("Hz", "")
+                                match = re.match(r"(\d+)x(\d+)(?:@([\d.]+))?", first_mode)
+                                if match:
+                                    mon.width = int(match.group(1))
+                                    mon.height = int(match.group(2))
+                                    mon.refresh_rate = (
+                                        float(match.group(3)) if match.group(3) else 60.0
+                                    )
+                    except Exception as hardware_error:
+                        self._window.show_toast(
+                            "Error finding available modes "
+                            + f"for re-enabled display: {hardware_error}",
+                            timeout=3,
+                            copy=True,
+                        )
+
+                    # Conditional Snapping: Check if enabling this monitor leaves a layout gap or causes an overlap
+                    active_others = [
+                        m
+                        for m in self._monitors
+                        if m.name != mon.name and not m.disabled and not m.mirror_of
+                    ]
+
+                    # Detect spatial collision/overlap with any currently active monitors
+                    has_overlap = False
+                    mw, mh = mon.effective_size
+                    for other in active_others:
+                        ow, oh = other.effective_size
+                        if (
+                            mon.x < other.x + ow
+                            and mon.x + mw > other.x
+                            and mon.y < other.y + oh
+                            and mon.y + mh > other.y
+                        ):
+                            has_overlap = True
+                            break
+
+                    # Snap to the right if there's an overlap or a gap in overall layout connectivity
+                    if has_overlap or not all_monitors_connected(self._monitors):
+                        if active_others:
+                            # Position it instantly adjacent to the far-right edge of the active layout
+                            mon.x = max(m.x + m.effective_size[0] for m in active_others)
+                            mon.y = 0
+                        # Align edges cleanly using a 0x0 baseline context
+                        adjust_neighbors(self._monitors, mon, 0, 0)
+
+                elif "width" in new_vals or "height" in new_vals:
                     vs = compute_valid_scales(mon.width, mon.height)
                     si = nearest_scale_index(vs, mon.scale)
                     mon.scale = vs[si][0]
-                if "disabled" not in new_vals and "mirror_of" not in new_vals:
+
+                if (
+                    not is_being_enabled
+                    and "disabled" not in new_vals
+                    and "mirror_of" not in new_vals
+                ):
                     adjust_neighbors(self._monitors, mon, old_w, old_h)
+
                 # Disabling a monitor clears any monitors mirroring it
                 if new_vals.get("disabled"):
                     for other in self._monitors:
                         if other.mirror_of == mon.name:
                             other.mirror_of = None
                             self._ownership.own(other.name)
+
                 if not try_with_toast(
                     self._window.show_bug_toast,
                     "Monitor config failed",
@@ -469,22 +559,6 @@ class MonitorsPage(SectionPage):
                 self._push_to_ui()
             finally:
                 self._applying = False
-        self._on_monitors_changed()
-        self._schedule_resync()
-
-    def _commit_to_hyprland(self):
-        """Send all monitors to Hyprland, push to UI."""
-        self._applying = True
-        try:
-            self._window.hypr.monitors.apply(self._monitors)
-        except HyprlandError as e:
-            self._applying = False
-            self._window.show_bug_toast(f"Monitor config failed — {e}", detail=str(e), timeout=5)
-            return
-        try:
-            self._push_to_ui()
-        finally:
-            self._applying = False
         self._on_monitors_changed()
         self._schedule_resync()
 
@@ -848,3 +922,20 @@ class MonitorsPage(SectionPage):
     def get_monitor_lines(self) -> list[str]:
         managed = [m for m in self._monitors if self._ownership.is_owned(m.name)]
         return [f"monitor = {line}" for line in lines_from_monitors(managed)]
+
+    def _fetch_hardware_monitors(self) -> list[dict[str, object]]:
+        """Query the global hardware list of all connected monitors from Hyprland IPC."""
+        result: list[dict[str, object]] = []
+        try:
+            # TODO 02/06/26 - self._window.hypr.monitors.get_all() should do this, but does not.
+            # Should update hyprland-state &| hyprland-socket with a function of either
+            # `hyprctl monitors` and `hyprctl monitors all`
+            output = subprocess.check_output(["hyprctl", "monitors", "all", "-j"], text=True)
+            data = json.loads(output)
+            if isinstance(data, list):
+                result = data
+        except Exception as e:
+            self._window.show_bug_toast(
+                f"Hyprctl monitors all -j failed — {e}", detail=str(e), timeout=5
+            )
+        return result

--- a/hyprmod/pages/monitors/page.py
+++ b/hyprmod/pages/monitors/page.py
@@ -185,9 +185,7 @@ class MonitorsPage(SectionPage):
         if not token:
             return None
         mon = resolve_identifier(token, self._monitors)
-        if mon:
-            return mon.name
-        return None
+        return mon.name if mon else None
 
     def _clear_unmanaged_extras(self, saved_lines: list[str]):
         """Clear IPC-leaked extras on managed monitors not in our config."""
@@ -428,6 +426,8 @@ class MonitorsPage(SectionPage):
 
                 for k, v in new_vals.items():
                     setattr(mon, k, v)
+                if is_being_enabled and mon.width == 0 and mon.height == 0:
+                    mon.mode = "preferred"
 
                 # Clear special keywords if explicit resolution/positioning changes are targeted
                 if not is_being_enabled:
@@ -600,7 +600,7 @@ class MonitorsPage(SectionPage):
         finally:
             self._applying = False
 
-        # 4. Only trigger change events if the geometry actually moved
+        # Only trigger change events if the geometry actually moved
         new_managed = [m for m in self._monitors if self._ownership.is_owned(m.name)]
         new_lines = sorted(lines_from_monitors(new_managed))
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,11 +6,12 @@ license = "GPL-3.0-or-later"
 requires-python = ">=3.12"
 dependencies = [
     "pygobject>=3.56.2",
-    "hyprland-config>=0.9.5",
+    "hyprland-config>=0.9.7",
     "hyprland-schema>=0.6.1",
     "hyprland-state>=0.4.2",
-    "hyprland-monitors>=0.7.0",
-    "hyprland-socket>=0.12.1",
+    "hyprland-monitors>=0.8.0",
+    "hyprland-monitors",
+    "hyprland-socket>=0.12.2",
 ]
 
 [dependency-groups]


### PR DESCRIPTION
Fixes several issues around disabling and re-enabling monitors.

- Re-enabling a disabled "island" monitor (no active adjacent neighbor) now uses `position = auto` instead of leaving it to overlap or snap onto another monitor's corner.
- Re-enabling a monitor whose dimensions are unknown (Hyprland reports `0x0` after a reboot) now sets `mode = preferred`, so it comes back at a valid resolution; the deferred resync then reads back real geometry.
- Guards against empty scale lists from `0x0` monitors at both card build and update, fixing a `scales must not be empty` crash.
- Explicit resolution/position changes (including preview drag) clear the `mode`/`position` keywords so numeric values take effect.

Note: the earlier "disabled monitors vanish from the page" issue was fixed upstream in BlueManCZ/hyprland-socket#2 / BlueManCZ/hyprland-monitors#1 and is already on main; this PR builds on those.

## Test Case

### The Monitor Auto-Snap Bug
**Starting State**: You have a monitor that is currently disabled and was previously entirely detached (an "island") from any other monitors. In the preview you see this disabled monitor greyed out, in active as an island.

**What You Do**: re-enable the disabled island monitor.

**What Happens on main (Buggy State)**: There is logic that checks if a monitor is "touching" another monitor, if it is then nothing happens. The re-enabled monitor stays in the place it would be, even if **overlapping**. When re-enabling island configured monitors where the logic says it is _not touching_ anything, the monitor snaps incorrectly to the top right corner of the other active monitor. This provides a very small entry gate to mouse between the two monitors.  

**What Should Happen Instead**: When re-enabling the monitor should maintain the logic of _"if touching do nothing"_ ELSE set position = "auto" which hyprland uses to snap to the right-most edge of the activate monitor layout. 