### PR TITLE
Fix anonymous multi-effect rules splitting into multiple UI rules

### DIFF
--- a/hyprmod/core/window_rules/_parse.py
+++ b/hyprmod/core/window_rules/_parse.py
@@ -8,10 +8,7 @@ that node type and hyprmod's UI-facing :class:`WindowRule` dataclass:
 
 - :func:`from_rule_node` adapts one ``Rule`` into a hyprmod
   :class:`WindowRule` (matchers → :class:`Matcher`, effects → :class:`Effect`).
-- :func:`from_rule_nodes` filters / converts a Document's full Rule list,
-  splitting anonymous multi-effect rules into N single-effect rules so
-  the page UI's "one effect per row" model holds (named rules stay
-  bundled — that's how the user authored them).
+- :func:`from_rule_nodes` filters / converts a Document's full Rule list.
 - :func:`serialize` produces the Hyprlang text per rule for the write
   path; the language-specific serializer in ``hyprland-config`` picks
   block vs. single-line based on the rule's contents.
@@ -51,34 +48,12 @@ def from_rule_node(node: Rule) -> WindowRule | None:
 
 
 def from_rule_nodes(nodes: list[Rule]) -> list[WindowRule]:
-    """Convert a Document's :class:`Rule` list into UI :class:`WindowRule`s.
-
-    Named rules stay bundled as one multi-effect WindowRule — that's how
-    the user authored them and :meth:`WindowRule.to_line` round-trips
-    them back to block form. *Anonymous* multi-effect rules get split
-    into N single-effect rules so the page's "one row per effect"
-    interaction model holds; on save, identical-matcher anonymous rules
-    serialize as separate single-line entries (semantically equivalent
-    to a bundled rule for Hyprland but matching how anonymous rules
-    are typically authored).
-    """
+    """Convert a Document's :class:`Rule` list into UI :class:`WindowRule`s."""
     out: list[WindowRule] = []
     for node in nodes:
         wr = from_rule_node(node)
-        if wr is None:
-            continue
-        if wr.name or len(wr.effects) <= 1:
+        if wr is not None:
             out.append(wr)
-            continue
-        # Anonymous multi-effect → split per effect.
-        for effect in wr.effects:
-            out.append(
-                WindowRule(
-                    matchers=list(wr.matchers),
-                    effects=[effect],
-                    enabled=wr.enabled,
-                )
-            )
     return out
 
 
@@ -103,8 +78,7 @@ def parse_window_rule_line(line: str) -> WindowRule | None:
     broken lines, or rules with no effects.
 
     Multi-effect / named blocks return one :class:`WindowRule` with all
-    effects bundled. Anonymous multi-effect single-line input returns
-    the *first* effect (use :func:`parse_window_rule_lines` to get all).
+    effects bundled.
     """
     rules = parse_window_rule_lines([line])
     return rules[0] if rules else None
@@ -113,9 +87,7 @@ def parse_window_rule_line(line: str) -> WindowRule | None:
 def parse_window_rule_lines(lines: list[str]) -> list[WindowRule]:
     """Parse multiple Hyprlang rule lines via the canonical pipeline.
 
-    Same routing as :func:`parse_window_rule_line` but processes a list
-    and splits anonymous multi-effect rules into N single-effect rules
-    (the page UI's one-row-per-effect model). Named rules stay bundled.
+    Same routing as :func:`parse_window_rule_line` but processes a list.
     Lines that aren't windowrules (or that fail to produce a Rule) are
     silently dropped.
     """

--- a/tests/test_window_rules.py
+++ b/tests/test_window_rules.py
@@ -277,19 +277,15 @@ class TestRoundTrip:
         )
         assert rule.to_line().endswith(", opacity 0.8 0.95")
 
-    def test_multi_effect_v3_splits_into_separate_rules(self):
+    def test_multi_effect_v3_stays_bundled(self):
         # ``windowrule = match:class kitty, opacity 0.8, no_blur on``
-        # has two effects on one line — Hyprland-valid, but we model
-        # one effect per rule. The list parser splits these so the
-        # round-trip preserves both effects.
+        # has two effects on one line — Hyprland-valid, and we now model
+        # multiple effects per rule in the UI, so it stays bundled.
         out = parse_window_rule_lines(
             ["windowrule = match:class ^(kitty)$, opacity 0.8 0.8, no_blur on"]
         )
-        assert len(out) == 2
-        assert out[0].effect_name == "opacity"
-        assert out[1].effect_name == "no_blur"
-        # Same matchers on both.
-        assert out[0].matchers == out[1].matchers
+        assert len(out) == 1
+        assert [e.name for e in out[0].effects] == ["opacity", "no_blur"]
 
 
 class TestNamedBlockRules:
@@ -346,13 +342,13 @@ class TestNamedBlockRules:
         assert rules[0].name == "off"
         assert rules[0].enabled is False
 
-    def test_anonymous_multi_effect_still_splits(self):
-        # No name → split per effect so each effect lives on its own
-        # row in the UI's one-effect-per-row model.
+    def test_anonymous_multi_effect_stays_bundled(self):
+        # No name → used to split per effect for a one-effect-per-row model.
+        # Now the UI supports multiple actions, so anonymous rules stay bundled.
         rules = parse_window_rule_lines(["windowrule = match:class kitty, opacity 0.8, no_blur on"])
-        assert len(rules) == 2
-        assert all(r.name == "" for r in rules)
-        assert [r.effects[0].name for r in rules] == ["opacity", "no_blur"]
+        assert len(rules) == 1
+        assert rules[0].name == ""
+        assert [e.name for e in rules[0].effects] == ["opacity", "no_blur"]
 
     def test_serialize_named_emits_block(self):
         rule = WindowRule(


### PR DESCRIPTION
In relation to my last PR
Anonymous window rules were showing as separate entries when using more than one action.