### PR TITLE
feat(plugins): add native Hyprland plugin configuration support

### DIFF
--- a/hyprmod/core/config.py
+++ b/hyprmod/core/config.py
@@ -37,51 +37,7 @@ from hyprland_config import (
 
 log = logging.getLogger(__name__)
 
-try:
-    import hyprland_config._lua._read._runner
 
-    _old_wrapper = hyprland_config._lua._read._runner._WRAPPER_SCRIPT
-    _new_wrapper = Path(__file__).parent / "_hyprland_config_wrapper.lua"
-    if not _new_wrapper.exists() or _new_wrapper.stat().st_mtime < _old_wrapper.stat().st_mtime:
-        _src = _old_wrapper.read_text()
-        _injection = """
-    local path = package.searchpath(modname, package.path)
-    if path then
-        local f = _real_loadfile(path)
-        if f then
-            record("__dofile_enter", path)
-            local prev = current_source
-            current_source = path
-            local ok, result = pcall(f)
-            current_source = prev
-            record("__dofile_exit", path)
-            if not ok then
-                record("__error", "require failed: " .. tostring(result))
-                return
-            end
-            return result
-        end
-    end
-    return _real_require(modname)
-"""
-        _src = _src.replace("    return _real_require(modname)", _injection)
-        _plugin_injection = """hl.plugin = {
-    load = function(path) record("plugin_load", path) end,
-}
-setmetatable(hl.plugin, {
-    __index = function(self, key)
-        if key == "load" then return rawget(self, key) end
-        return true
-    end
-})"""
-        _src = _src.replace(
-            'hl.plugin = {\n    load = function(path) record("plugin_load", path) end,\n}',
-            _plugin_injection,
-        )
-        _new_wrapper.write_text(_src)
-    hyprland_config._lua._read._runner._WRAPPER_SCRIPT = _new_wrapper
-except ImportError:
-    pass
 
 
 @dataclass(slots=True)

--- a/hyprmod/core/config.py
+++ b/hyprmod/core/config.py
@@ -34,6 +34,7 @@ from hyprland_config import (
     serialize_any,
     serialize_hyprlang,
 )
+from hyprland_config._migrate._windowrule import normalize_rules
 
 log = logging.getLogger(__name__)
 
@@ -507,6 +508,7 @@ def _build_document(values: dict[str, str], sections: ConfigSections) -> Documen
     if sections.exec_:
         _add_section(doc, "Autostart", sections.exec_)
 
+    normalize_rules(doc)
     return doc
 
 

--- a/hyprmod/core/config.py
+++ b/hyprmod/core/config.py
@@ -357,10 +357,6 @@ def read_all_sections(
         elif isinstance(line, Rule):
             rules.append(line)
 
-    plugin_items = list(doc.section("plugin"))
-    if plugin_items:
-        sections["plugin"] = [item.raw for item in plugin_items]
-
     return options, sections, rules
 
 
@@ -558,8 +554,7 @@ def to_managed_text(
     """
     doc = _build_document(values, sections)
     _log_deprecations(doc, hyprland_version=hyprland_version)
-    out = serialize_any(doc, managed_path())
-    return out
+    return serialize_any(doc, managed_path())
 
 
 def write_all(

--- a/hyprmod/core/config.py
+++ b/hyprmod/core/config.py
@@ -37,6 +37,52 @@ from hyprland_config import (
 
 log = logging.getLogger(__name__)
 
+try:
+    import hyprland_config._lua._read._runner
+
+    _old_wrapper = hyprland_config._lua._read._runner._WRAPPER_SCRIPT
+    _new_wrapper = Path(__file__).parent / "_hyprland_config_wrapper.lua"
+    if not _new_wrapper.exists() or _new_wrapper.stat().st_mtime < _old_wrapper.stat().st_mtime:
+        _src = _old_wrapper.read_text()
+        _injection = """
+    local path = package.searchpath(modname, package.path)
+    if path then
+        local f = _real_loadfile(path)
+        if f then
+            record("__dofile_enter", path)
+            local prev = current_source
+            current_source = path
+            local ok, result = pcall(f)
+            current_source = prev
+            record("__dofile_exit", path)
+            if not ok then
+                record("__error", "require failed: " .. tostring(result))
+                return
+            end
+            return result
+        end
+    end
+    return _real_require(modname)
+"""
+        _src = _src.replace("    return _real_require(modname)", _injection)
+        _plugin_injection = """hl.plugin = {
+    load = function(path) record("plugin_load", path) end,
+}
+setmetatable(hl.plugin, {
+    __index = function(self, key)
+        if key == "load" then return rawget(self, key) end
+        return true
+    end
+})"""
+        _src = _src.replace(
+            'hl.plugin = {\n    load = function(path) record("plugin_load", path) end,\n}',
+            _plugin_injection,
+        )
+        _new_wrapper.write_text(_src)
+    hyprland_config._lua._read._runner._WRAPPER_SCRIPT = _new_wrapper
+except ImportError:
+    pass
+
 
 @dataclass(slots=True)
 class ConfigSections:
@@ -56,6 +102,7 @@ class ConfigSections:
     exec_: list[str] | None = None
     window_rules: list[str] | None = None
     layer_rules: list[str] | None = None
+    plugins: list[str] | None = None
 
 
 HYPRMOD_DIR = Path.home() / ".config" / "hypr" / "hyprmod"
@@ -355,6 +402,11 @@ def read_all_sections(
             sections.setdefault(line.key, []).append(line.raw.strip())
         elif isinstance(line, Rule):
             rules.append(line)
+
+    plugin_items = list(doc.section("plugin"))
+    if plugin_items:
+        sections["plugin"] = [item.raw for item in plugin_items]
+
     return options, sections, rules
 
 
@@ -472,15 +524,14 @@ def _build_document(values: dict[str, str], sections: ConfigSections) -> Documen
         _add_section(doc, "Environment", sections.env)
 
     if values:
-        # Bare option lines (general:gaps_in, decoration:rounding, …) live
-        # under their own header so the Lua emitter — which treats Comments
-        # as group boundaries — keeps them in a dedicated ``hl.config(...)``
-        # call instead of absorbing them into the preceding section's group.
-        _add_section(
-            doc,
-            "Settings",
-            [f"{k} = {v}" for k, v in sorted(values.items())],
-        )
+        general_values = {k: v for k, v in values.items() if not k.startswith("plugin:")}
+
+        if general_values:
+            _add_section(
+                doc,
+                "Settings",
+                [f"{k} = {v}" for k, v in sorted(general_values.items())],
+            )
 
     if sections.beziers:
         _add_section(doc, "Bezier curves", sections.beziers)
@@ -492,12 +543,14 @@ def _build_document(values: dict[str, str], sections: ConfigSections) -> Documen
         _add_section(doc, "Workspaces", sections.workspaces)
     if sections.binds:
         _add_section(doc, "Keybinds", sections.binds)
-    # Window rules sit before autostart so any rule overrides are in effect
-    # before exec'd processes spawn matching windows on reload.
     if sections.window_rules:
         _add_section(doc, "Window rules", sections.window_rules)
     if sections.layer_rules:
         _add_section(doc, "Layer rules", sections.layer_rules)
+
+    if sections.plugins:
+        _add_section(doc, "Plugins", sections.plugins)
+
     # Autostart last: ``exec`` re-runs on every reload, so config later in
     # the file that affects the exec'd process (env vars, monitor layout)
     # is already in effect by the time the commands run.
@@ -551,7 +604,17 @@ def to_managed_text(
     """
     doc = _build_document(values, sections)
     _log_deprecations(doc, hyprland_version=hyprland_version)
-    return serialize_any(doc, managed_path())
+    out = serialize_any(doc, managed_path())
+    if is_lua_mode():
+        import re
+
+        def wrap_plugin(match):
+            name = match.group(1)
+            body = match.group(2)
+            return f"-- Plugin: {name}\nif hl.plugin.{name} then\n{body}end\n"
+
+        out = re.sub(r"-- Plugin: ([\w-]+)\n(hl\.config\(\{[\s\S]*?\}\)\n)", wrap_plugin, out)
+    return out
 
 
 def write_all(

--- a/hyprmod/core/config.py
+++ b/hyprmod/core/config.py
@@ -605,15 +605,6 @@ def to_managed_text(
     doc = _build_document(values, sections)
     _log_deprecations(doc, hyprland_version=hyprland_version)
     out = serialize_any(doc, managed_path())
-    if is_lua_mode():
-        import re
-
-        def wrap_plugin(match):
-            name = match.group(1)
-            body = match.group(2)
-            return f"-- Plugin: {name}\nif hl.plugin.{name} then\n{body}end\n"
-
-        out = re.sub(r"-- Plugin: ([\w-]+)\n(hl\.config\(\{[\s\S]*?\}\)\n)", wrap_plugin, out)
     return out
 
 

--- a/hyprmod/core/config.py
+++ b/hyprmod/core/config.py
@@ -38,8 +38,6 @@ from hyprland_config import (
 log = logging.getLogger(__name__)
 
 
-
-
 @dataclass(slots=True)
 class ConfigSections:
     """Per-section line buffers for a single :func:`write_all` invocation.

--- a/hyprmod/core/plugins.py
+++ b/hyprmod/core/plugins.py
@@ -42,7 +42,6 @@ def serialize(settings: list[PluginSetting]) -> list[str]:
 
     lines = []
     for plugin_name, plugin_settings in by_plugin.items():
-        lines.append(f"# Plugin: {plugin_name}\n")
         lines.append("plugin {\n")
         lines.append(f"  {plugin_name} {{\n")
         for setting in plugin_settings:

--- a/hyprmod/core/plugins.py
+++ b/hyprmod/core/plugins.py
@@ -1,0 +1,124 @@
+"""Data models and parsing for plugin settings."""
+
+from dataclasses import dataclass
+from pathlib import Path
+
+import hyprland_config
+from hyprland_config import Assignment
+
+
+@dataclass(slots=True)
+class PluginSetting:
+    plugin_name: str
+    key: str
+    value: str
+
+    def to_line(self) -> str:
+        return f"{self.key} = {self.value}"
+
+
+def parse_plugin_options(options: dict[str, str]) -> list[PluginSetting]:
+    """Extract plugin settings from flattened config options."""
+    settings = []
+    for full_key, value in options.items():
+        if full_key.startswith("plugin:"):
+            parts = full_key.split(":")
+            if len(parts) >= 3:
+                plugin_name = parts[1]
+                key = ":".join(parts[2:])
+                settings.append(PluginSetting(plugin_name, key, value))
+    return settings
+
+
+def serialize(settings: list[PluginSetting]) -> list[str]:
+    """Serialize a list of PluginSettings into raw lines for the `plugin { ... }` block."""
+    if not settings:
+        return []
+
+    # Group by plugin_name
+    by_plugin = {}
+    for setting in settings:
+        by_plugin.setdefault(setting.plugin_name, []).append(setting)
+
+    lines = []
+    for plugin_name, plugin_settings in by_plugin.items():
+        lines.append(f"# Plugin: {plugin_name}\n")
+        lines.append("plugin {\n")
+        lines.append(f"  {plugin_name} {{\n")
+        for setting in plugin_settings:
+            lines.append(f"    {setting.to_line()}\n")
+        lines.append("  }\n")
+        lines.append("}\n")
+
+    return lines
+
+
+@dataclass(frozen=True, slots=True)
+class ExternalPluginSetting:
+    setting: PluginSetting
+    source_path: Path
+    lineno: int
+
+
+def load_external_plugins(root_path: Path, managed_path: Path) -> list[ExternalPluginSetting]:
+    if not root_path.exists():
+        return []
+    try:
+        doc = hyprland_config.load_any(root_path, follow_sources=True, lenient=True)
+    except (OSError, hyprland_config.ParseError, hyprland_config.SourceCycleError):
+        return []
+
+    try:
+        managed_resolved = managed_path.resolve()
+    except OSError:
+        managed_resolved = managed_path
+
+    external = []
+
+    def _walk(d):
+        for it in d.lines:
+            yield it
+            if type(it).__name__ == "Source" and it.documents:
+                yield from _walk(it.documents[0])
+
+    for item in _walk(doc):
+        if isinstance(item, Assignment) and item.full_key.startswith("plugin:"):
+            entry_path = Path(item.source_name)
+            try:
+                entry_resolved = entry_path.resolve()
+            except OSError:
+                entry_resolved = entry_path
+
+            if entry_resolved == managed_resolved:
+                continue
+
+            parts = item.full_key.split(":")
+            if len(parts) >= 3:
+                plugin_name = parts[1]
+                key = ":".join(parts[2:])
+                setting = PluginSetting(
+                    plugin_name=plugin_name,
+                    key=key,
+                    value=item.value,
+                )
+                external.append(
+                    ExternalPluginSetting(
+                        setting=setting,
+                        source_path=entry_path,
+                        lineno=item.lineno,
+                    )
+                )
+
+    return external
+
+
+def overridden_external_plugins(
+    external: list[ExternalPluginSetting],
+    owned: list[PluginSetting],
+) -> set[str]:
+    owned_keys = {f"{e.plugin_name}:{e.key}" for e in owned}
+    return {
+        f"{ext.setting.plugin_name}:{ext.setting.key}"
+        for ext in external
+        if f"{ext.setting.plugin_name}:{ext.setting.key}" in owned_keys
+    }

--- a/hyprmod/core/plugins.py
+++ b/hyprmod/core/plugins.py
@@ -110,5 +110,3 @@ def load_external_plugins(root_path: Path, managed_path: Path) -> list[ExternalP
                 )
 
     return external
-
-

--- a/hyprmod/core/plugins.py
+++ b/hyprmod/core/plugins.py
@@ -112,13 +112,3 @@ def load_external_plugins(root_path: Path, managed_path: Path) -> list[ExternalP
     return external
 
 
-def overridden_external_plugins(
-    external: list[ExternalPluginSetting],
-    owned: list[PluginSetting],
-) -> set[str]:
-    owned_keys = {f"{e.plugin_name}:{e.key}" for e in owned}
-    return {
-        f"{ext.setting.plugin_name}:{ext.setting.key}"
-        for ext in external
-        if f"{ext.setting.plugin_name}:{ext.setting.key}" in owned_keys
-    }

--- a/hyprmod/core/schema.py
+++ b/hyprmod/core/schema.py
@@ -30,6 +30,29 @@ def load_schema(version: str | None = None, path: Path | None = None) -> dict:
     return overlay
 
 
+def load_plugin_schemas(plugins_dir: Path | None = None) -> list[dict]:
+    """Load and return all plugin schema groups."""
+    if plugins_dir is None:
+        plugins_dir = Path(__file__).parent.parent / "data" / "schema" / "plugins"
+
+    if not plugins_dir.exists():
+        return []
+
+    plugins = []
+    for path in plugins_dir.glob("*.json"):
+        with open(path, encoding="utf-8") as f:
+            plugin_group = json.load(f)
+            plugins.append(plugin_group)
+
+    # Remove any options that lack a type, similar to _drop_unavailable
+    for group in plugins:
+        for section in group.get("sections", []):
+            kept_options = [opt for opt in section.get("options", []) if "type" in opt]
+            section["options"] = kept_options
+
+    return plugins
+
+
 def _resolve_schema_options(version: str | None) -> Mapping[str, HyprOption]:
     """Resolve the version-matched option catalog, falling back to the bundle."""
     if version is None:

--- a/hyprmod/data/schema/plugins/hypr-dynamic-cursors.json
+++ b/hyprmod/data/schema/plugins/hypr-dynamic-cursors.json
@@ -1,0 +1,236 @@
+{
+  "id": "plugin:hypr-dynamic-cursors",
+  "label": "Hypr Dynamic Cursors",
+  "icon": "input-mouse-symbolic",
+  "description": "Cursor behaviour based on velocity",
+  "sections": [
+    {
+      "id": "plugin:dynamic_cursors:general",
+      "label": "General",
+      "options": [
+        {
+          "key": "plugin:dynamic_cursors:enabled",
+          "label": "Enabled",
+          "description": "Enables the plugin",
+          "type": "bool",
+          "default": true
+        },
+        {
+          "key": "plugin:dynamic_cursors:mode",
+          "label": "Mode",
+          "description": "Cursor behaviour mode",
+          "type": "choice",
+          "values": [
+            {"id": "tilt", "label": "Tilt"},
+            {"id": "rotate", "label": "Rotate"},
+            {"id": "stretch", "label": "Stretch"},
+            {"id": "none", "label": "None"}
+          ],
+          "default": "tilt"
+        },
+        {
+          "key": "plugin:dynamic_cursors:threshold",
+          "label": "Threshold",
+          "description": "Minimum angle difference in degrees after which the shape is changed.",
+          "type": "int",
+          "default": 2
+        }
+      ]
+    },
+    {
+      "id": "plugin:dynamic_cursors:rotate",
+      "label": "Rotate Settings",
+      "depends_on": "plugin:dynamic_cursors:mode=rotate",
+      "options": [
+        {
+          "key": "plugin:dynamic_cursors:rotate:length",
+          "label": "Simulated Stick Length",
+          "description": "Length in px of the simulated stick used to rotate the cursor.",
+          "type": "int",
+          "default": 20
+        },
+        {
+          "key": "plugin:dynamic_cursors:rotate:offset",
+          "label": "Angle Offset",
+          "description": "Clockwise offset applied to the angle in degrees.",
+          "type": "float",
+          "default": 0.0
+        }
+      ]
+    },
+    {
+      "id": "plugin:dynamic_cursors:tilt",
+      "label": "Tilt Settings",
+      "depends_on": "plugin:dynamic_cursors:mode=tilt",
+      "options": [
+        {
+          "key": "plugin:dynamic_cursors:tilt:limit",
+          "label": "Tilt Limit",
+          "description": "Controls how powerful the tilt is, the lower, the more power.",
+          "type": "int",
+          "default": 5000
+        },
+        {
+          "key": "plugin:dynamic_cursors:tilt:activation",
+          "label": "Activation Function",
+          "description": "Relationship between speed and tilt.",
+          "type": "choice",
+          "values": [
+            {"id": "linear", "label": "Linear"},
+            {"id": "quadratic", "label": "Quadratic"},
+            {"id": "negative_quadratic", "label": "Negative Quadratic"}
+          ],
+          "default": "negative_quadratic"
+        },
+        {
+          "key": "plugin:dynamic_cursors:tilt:window",
+          "label": "Time Window",
+          "description": "Time window (ms) over which the speed is calculated.",
+          "type": "int",
+          "default": 100
+        },
+        {
+          "key": "plugin:dynamic_cursors:tilt:full",
+          "label": "Full Tilt Angle",
+          "description": "Full tilt for each side (°).",
+          "type": "int",
+          "default": 60
+        }
+      ]
+    },
+    {
+      "id": "plugin:dynamic_cursors:stretch",
+      "label": "Stretch Settings",
+      "depends_on": "plugin:dynamic_cursors:mode=stretch",
+      "options": [
+        {
+          "key": "plugin:dynamic_cursors:stretch:limit",
+          "label": "Stretch Limit",
+          "description": "Controls how much the cursor is stretched.",
+          "type": "int",
+          "default": 3000
+        },
+        {
+          "key": "plugin:dynamic_cursors:stretch:activation",
+          "label": "Activation Function",
+          "description": "Relationship between speed and stretch amount.",
+          "type": "choice",
+          "values": [
+            {"id": "linear", "label": "Linear"},
+            {"id": "quadratic", "label": "Quadratic"},
+            {"id": "negative_quadratic", "label": "Negative Quadratic"}
+          ],
+          "default": "quadratic"
+        },
+        {
+          "key": "plugin:dynamic_cursors:stretch:window",
+          "label": "Time Window",
+          "description": "Time window (ms) over which the speed is calculated.",
+          "type": "int",
+          "default": 100
+        }
+      ]
+    },
+    {
+      "id": "plugin:dynamic_cursors:shake",
+      "label": "Shake to Find",
+      "options": [
+        {
+          "key": "plugin:dynamic_cursors:shake:enabled",
+          "label": "Enable Shake to Find",
+          "description": "Magnifies the cursor if it is being shaken.",
+          "type": "bool",
+          "default": true
+        },
+        {
+          "key": "plugin:dynamic_cursors:shake:threshold",
+          "label": "Threshold",
+          "description": "Controls how soon a shake is detected.",
+          "type": "float",
+          "default": 6.0
+        },
+        {
+          "key": "plugin:dynamic_cursors:shake:base",
+          "label": "Base Magnification",
+          "type": "float",
+          "default": 4.0
+        },
+        {
+          "key": "plugin:dynamic_cursors:shake:speed",
+          "label": "Magnification Speed",
+          "type": "float",
+          "default": 4.0
+        },
+        {
+          "key": "plugin:dynamic_cursors:shake:influence",
+          "label": "Shake Influence",
+          "type": "float",
+          "default": 0.0
+        },
+        {
+          "key": "plugin:dynamic_cursors:shake:limit",
+          "label": "Magnification Limit",
+          "type": "float",
+          "default": 0.0
+        },
+        {
+          "key": "plugin:dynamic_cursors:shake:timeout",
+          "label": "Timeout (ms)",
+          "type": "int",
+          "default": 2000
+        },
+        {
+          "key": "plugin:dynamic_cursors:shake:effects",
+          "label": "Show Effects During Shake",
+          "type": "bool",
+          "default": false
+        },
+        {
+          "key": "plugin:dynamic_cursors:shake:ipc",
+          "label": "Enable IPC Events",
+          "type": "bool",
+          "default": false
+        }
+      ]
+    },
+    {
+      "id": "plugin:dynamic_cursors:hyprcursor",
+      "label": "Hyprcursor",
+      "options": [
+        {
+          "key": "plugin:dynamic_cursors:hyprcursor:nearest",
+          "label": "Pixelated Scaling",
+          "type": "choice",
+          "values": [
+            {"id": "0", "label": "None"},
+            {"id": "1", "label": "Standard"},
+            {"id": "2", "label": "Full"}
+          ],
+          "default": "1"
+        },
+        {
+          "key": "plugin:dynamic_cursors:hyprcursor:enabled",
+          "label": "Enable Hyprcursor Support",
+          "type": "bool",
+          "default": true
+        },
+        {
+          "key": "plugin:dynamic_cursors:hyprcursor:resolution",
+          "label": "Resolution",
+          "type": "int",
+          "default": -1
+        },
+        {
+          "key": "plugin:dynamic_cursors:hyprcursor:fallback",
+          "label": "Fallback Shape",
+          "type": "choice",
+          "values": [
+            {"id": "clientside", "label": "Clientside"},
+            {"id": "none", "label": "None"}
+          ],
+          "default": "clientside"
+        }
+      ]
+    }
+  ]
+}

--- a/hyprmod/pages/autostart.py
+++ b/hyprmod/pages/autostart.py
@@ -79,6 +79,22 @@ class AutostartPage(SavedListSectionPage[ExecData]):
         self._installed_apps: list[DesktopApp] = list_apps()
         self._load(saved_sections)
 
+    # ── Public API ──
+
+    def has_command(self, keyword: str, substring: str) -> bool:
+        """Return True if any entry matches the keyword and contains the substring."""
+        for entry in self._owned:
+            if entry.keyword == keyword and substring in (entry.command or ""):
+                return True
+        for ext in self._external:
+            if ext.entry.keyword == keyword and substring in (ext.entry.command or ""):
+                return True
+        return False
+
+    def add_command(self, keyword: str, command: str) -> None:
+        """Append a new command entry."""
+        self._commit_appended(ExecData(keyword=keyword, command=command))
+
     # ── Loading ──
 
     def _load(self, saved_sections: dict[str, list[str]] | None) -> None:

--- a/hyprmod/pages/plugins.py
+++ b/hyprmod/pages/plugins.py
@@ -52,7 +52,8 @@ class PluginsPage(SavedListSectionPage[PluginSetting]):
 
     # ── Loading ──
 
-    def _load(self) -> None:
+    def _load(self, saved_sections: dict[str, list[str]] | None = None) -> None:
+        del saved_sections
         saved_values = self._window.saved_values
         items = parse_plugin_options(saved_values)
 
@@ -71,7 +72,7 @@ class PluginsPage(SavedListSectionPage[PluginSetting]):
         return list(self._owned)
 
     def reload_from_saved(self, saved_sections: dict[str, list[str]]) -> None:
-        self._load()
+        self._load(saved_sections)
         self._rebuild_list()
 
     # ── Build ──

--- a/hyprmod/pages/plugins.py
+++ b/hyprmod/pages/plugins.py
@@ -182,7 +182,8 @@ class PluginsPage(SavedListSectionPage[PluginSetting]):
                 if entry.keyword == "exec-once" and "hyprpm reload" in (entry.command or ""):
                     return True
             for ext in autostart_page._external:
-                if ext.setting.keyword == "exec-once" and "hyprpm reload" in (ext.setting.command or ""):
+                ext_cmd = ext.setting.command or ""
+                if ext.setting.keyword == "exec-once" and "hyprpm reload" in ext_cmd:
                     return True
             return False
 
@@ -191,13 +192,16 @@ class PluginsPage(SavedListSectionPage[PluginSetting]):
                 autostart_page = getattr(self._window, "_autostart_page", None)
                 if autostart_page:
                     from hyprmod.core.autostart import ExecData
-                    autostart_page._commit_appended(ExecData(keyword="exec-once", command="hyprpm reload -n"))
+
+                    data = ExecData(keyword="exec-once", command="hyprpm reload -n")
+                    autostart_page._commit_appended(data)
                     self._rebuild_list()
 
             from hyprmod.ui import make_inline_hint
-            
+
             hint = make_inline_hint(
-                "Plugins must be loaded to configure them. Add <code>hyprpm reload</code> to autostart?",
+                "Plugins must be loaded to configure them. "
+                "Add <code>hyprpm reload</code> to autostart?",
                 button_label="Add to Autostart",
                 button_callback=on_add_autostart,
             )

--- a/hyprmod/pages/plugins.py
+++ b/hyprmod/pages/plugins.py
@@ -112,6 +112,7 @@ class PluginsPage(SavedListSectionPage[PluginSetting]):
     def _build_managed_groups(self) -> list[Gtk.Widget]:
         groups = []
         supported = schema.load_plugin_schemas()
+        any_not_loaded = False
 
         if supported:
             supported_group = Adw.PreferencesGroup(title="Supported Plugins")
@@ -134,7 +135,8 @@ class PluginsPage(SavedListSectionPage[PluginSetting]):
                     state = self._window.app_state.get(main_toggle_key)
                     if state:
                         if not state.available:
-                            status_text = "Not installed"
+                            status_text = "Not loaded"
+                            any_not_loaded = True
                         else:
                             is_enabled = bool(state.live_value)
 
@@ -168,6 +170,38 @@ class PluginsPage(SavedListSectionPage[PluginSetting]):
                 )
                 supported_group.add(row)
             groups.append(supported_group)
+
+        import shutil
+        has_hyprpm = shutil.which("hyprpm") is not None
+
+        def has_hyprpm_autostart() -> bool:
+            autostart_page = getattr(self._window, "_autostart_page", None)
+            if not autostart_page:
+                return True
+            for entry in autostart_page._owned:
+                if entry.keyword == "exec-once" and "hyprpm reload" in (entry.command or ""):
+                    return True
+            for ext in autostart_page._external:
+                if ext.setting.keyword == "exec-once" and "hyprpm reload" in (ext.setting.command or ""):
+                    return True
+            return False
+
+        if any_not_loaded and has_hyprpm and not has_hyprpm_autostart():
+            def on_add_autostart(_btn) -> None:
+                autostart_page = getattr(self._window, "_autostart_page", None)
+                if autostart_page:
+                    from hyprmod.core.autostart import ExecData
+                    autostart_page._commit_appended(ExecData(keyword="exec-once", command="hyprpm reload -n"))
+                    self._rebuild_list()
+
+            from hyprmod.ui import make_inline_hint
+            
+            hint = make_inline_hint(
+                "Plugins must be loaded to configure them. Add <code>hyprpm reload</code> to autostart?",
+                button_label="Add to Autostart",
+                button_callback=on_add_autostart,
+            )
+            groups.insert(0, hint)
 
         if len(self._owned) > 0:
             custom = self._build_managed_group("Custom Plugins", range(len(self._owned)))

--- a/hyprmod/pages/plugins.py
+++ b/hyprmod/pages/plugins.py
@@ -59,11 +59,16 @@ class PluginsPage(SavedListSectionPage[PluginSetting]):
         custom_items = []
         for e in items:
             full_key = f"plugin:{e.plugin_name}:{e.key}"
-            if full_key not in self._window._options_flat:
+            if full_key not in self._window.options_flat:
                 custom_items.append(e)
 
         self._owned = SavedList(custom_items, key=lambda e: f"{e.plugin_name}:{e.key}")
         self._external = load_external_plugins(config.user_entry_path(), config.managed_path())
+
+    @property
+    def custom_plugins(self) -> list[PluginSetting]:
+        """Return the list of custom plugin settings managed by this page."""
+        return list(self._owned)
 
     def reload_from_saved(self, saved_sections: dict[str, list[str]]) -> None:
         self._load()

--- a/hyprmod/pages/plugins.py
+++ b/hyprmod/pages/plugins.py
@@ -41,7 +41,6 @@ class PluginsPage(SavedListSectionPage[PluginSetting]):
         window,
         on_dirty_changed=None,
         push_undo=None,
-        **kwargs,
     ):
         super().__init__(window, on_dirty_changed, push_undo)
         self._content_box: Gtk.Box

--- a/hyprmod/pages/plugins.py
+++ b/hyprmod/pages/plugins.py
@@ -41,6 +41,7 @@ class PluginsPage(SavedListSectionPage[PluginSetting]):
         window,
         on_dirty_changed=None,
         push_undo=None,
+        **kwargs,
     ):
         super().__init__(window, on_dirty_changed, push_undo)
         self._content_box: Gtk.Box

--- a/hyprmod/pages/plugins.py
+++ b/hyprmod/pages/plugins.py
@@ -178,7 +178,7 @@ class PluginsPage(SavedListSectionPage[PluginSetting]):
         page = Adw.PreferencesPage(title="")
         page.set_icon_name(schema_group.get("icon", ""))
 
-        for pref_group in self._window.build_schema_group_widgets(schema_group["id"]):
+        for pref_group in self._window.build_schema_group_widgets(schema_group):
             page.add(pref_group)
 
         dialog.add(page)

--- a/hyprmod/pages/plugins.py
+++ b/hyprmod/pages/plugins.py
@@ -7,7 +7,6 @@ This page provides a list editor to add, edit, and remove those settings.
 from html import escape as html_escape
 
 from gi.repository import Adw, Gtk
-
 from hyprland_socket import HyprlandError
 
 from hyprmod.core import config, schema

--- a/hyprmod/pages/plugins.py
+++ b/hyprmod/pages/plugins.py
@@ -110,10 +110,44 @@ class PluginsPage(SavedListSectionPage[PluginSetting]):
         if supported:
             supported_group = Adw.PreferencesGroup(title="Supported Plugins")
             for schema_group in supported:
+                plugin_keys = []
+                main_toggle_key = None
+                main_toggle_default = True
+
+                for section in schema_group.get("sections", []):
+                    for option in section.get("options", []):
+                        k = option["key"]
+                        plugin_keys.append(k)
+                        if k.endswith(":enabled") and k.count(":") == 2:
+                            main_toggle_key = k
+                            main_toggle_default = option.get("default", True)
+
+                is_enabled = main_toggle_default
+                if main_toggle_key:
+                    state = self._window.app_state.get(main_toggle_key)
+                    if state:
+                        is_enabled = bool(state.live_value)
+
+                managed_count = sum(
+                    1
+                    for k in plugin_keys
+                    if (state := self._window.app_state.get(k)) and state.managed
+                )
+
+                status_text = "Enabled" if is_enabled else "Disabled"
+                if managed_count > 0:
+                    plural = "s" if managed_count > 1 else ""
+                    status_text += f" • {managed_count} custom setting{plural}"
+
+                desc = schema_group.get("description")
+                subtitle = f"{status_text}\n{desc}" if desc else status_text
+
                 row = Adw.ActionRow(
                     title=schema_group["label"],
-                    subtitle=schema_group.get("description", "Click to configure"),
+                    subtitle=subtitle,
                 )
+                row.set_subtitle_lines(0)
+
                 if "icon" in schema_group:
                     icon = Gtk.Image.new_from_icon_name(schema_group["icon"])
                     row.add_prefix(icon)
@@ -143,6 +177,7 @@ class PluginsPage(SavedListSectionPage[PluginSetting]):
             page.add(pref_group)
 
         dialog.add(page)
+        dialog.connect("closed", lambda _d: self._rebuild_list())
         dialog.present(self._window)
 
     def _deleted_row_summary(self, item: PluginSetting) -> tuple[str, str]:

--- a/hyprmod/pages/plugins.py
+++ b/hyprmod/pages/plugins.py
@@ -348,16 +348,14 @@ class PluginsPage(SavedListSectionPage[PluginSetting]):
         self._apply_live(f"plugin:{item.plugin_name}:{item.key}", item.value or "")
 
     def _on_delete_at(self, idx: int) -> None:
-        item = self._owned[idx]
         super()._on_delete_at(idx)
-        self._apply_live(f"plugin:{item.plugin_name}:{item.key}", "")
 
     def _discard_at(self, idx: int) -> None:
         item = self._owned[idx]
         baseline = self._owned.get_baseline(idx)
         super()._discard_at(idx)
-        value = baseline.value if baseline else ""
-        self._apply_live(f"plugin:{item.plugin_name}:{item.key}", value)
+        if baseline:
+            self._apply_live(f"plugin:{item.plugin_name}:{item.key}", baseline.value or "")
 
     def _on_restore_deleted(self, item: PluginSetting) -> None:
         super()._on_restore_deleted(item)

--- a/hyprmod/pages/plugins.py
+++ b/hyprmod/pages/plugins.py
@@ -140,11 +140,11 @@ class PluginsPage(SavedListSectionPage[PluginSetting]):
                 if not status_text:
                     status_text = "Enabled" if is_enabled else "Disabled"
 
-                managed_count = sum(
-                    1
-                    for k in plugin_keys
-                    if (state := self._window.app_state.get(k)) and state.managed
-                )
+                def is_managed(k: str) -> bool:
+                    state = self._window.app_state.get(k)
+                    return state.managed if state else k in self._window.saved_values
+
+                managed_count = sum(1 for k in plugin_keys if is_managed(k))
                 if managed_count > 0:
                     plural = "s" if managed_count > 1 else ""
                     status_text += f" • {managed_count} custom setting{plural}"

--- a/hyprmod/pages/plugins.py
+++ b/hyprmod/pages/plugins.py
@@ -1,0 +1,287 @@
+"""Plugin Settings page — manage custom plugin configurations.
+
+Plugins define their own settings nested inside the `plugin { ... }` block.
+This page provides a list editor to add, edit, and remove those settings.
+"""
+
+from html import escape as html_escape
+
+from gi.repository import Adw, Gtk
+
+from hyprmod.core import config, schema
+from hyprmod.core.ownership import SavedList
+from hyprmod.core.plugins import (
+    ExternalPluginSetting,
+    PluginSetting,
+    load_external_plugins,
+    parse_plugin_options,
+)
+from hyprmod.pages.section import SavedListSectionPage
+from hyprmod.ui import make_page_layout
+from hyprmod.ui.empty_state import EmptyState
+from hyprmod.ui.icons import PLUGINS_ICON
+from hyprmod.ui.plugin_setting_edit_dialog import PluginSettingEditDialog
+from hyprmod.ui.row_actions import RowActions
+
+
+class PluginsPage(SavedListSectionPage[PluginSetting]):
+    """List editor for `plugin { ... }` config entries."""
+
+    _unit_singular = "setting"
+    _unit_plural = "settings"
+    _page_attr = "_plugins_page"
+    _pending_category = "Plugin Settings"
+    _pending_navigate_to = "plugins"
+    _pending_icon = PLUGINS_ICON
+    _group_title = "Plugin Settings"
+    _group_add_tooltip = "Add a plugin setting"
+
+    def __init__(
+        self,
+        window,
+        on_dirty_changed=None,
+        push_undo=None,
+        saved_sections=None,
+    ):
+        super().__init__(window, on_dirty_changed, push_undo)
+        self._content_box: Gtk.Box
+        self._scrolled: Gtk.ScrolledWindow
+        self._owned: SavedList[PluginSetting]
+        self._overridden_external: set[str] = set()
+        self._load()
+
+    # ── Loading ──
+
+    def _load(self, saved_sections: dict[str, list[str]] | None = None) -> None:
+        saved_values = self._window.saved_values
+        items = parse_plugin_options(saved_values)
+
+        custom_items = []
+        for e in items:
+            full_key = f"plugin:{e.plugin_name}:{e.key}"
+            if full_key not in self._window._options_flat:
+                custom_items.append(e)
+
+        self._owned = SavedList(custom_items, key=lambda e: f"{e.plugin_name}:{e.key}")
+        self._external = load_external_plugins(config.user_entry_path(), config.managed_path())
+
+    def reload_from_saved(self, saved_sections: dict[str, list[str]]) -> None:
+        self._load()
+        self._rebuild_list()
+
+    # ── Build ──
+
+    def build(self, header: Adw.HeaderBar | None = None) -> Adw.ToolbarView:
+        page_header = header or Adw.HeaderBar()
+
+        add_btn = Gtk.Button(icon_name="list-add-symbolic")
+        add_btn.set_tooltip_text("Add plugin setting")
+        add_btn.connect("clicked", lambda _b: self._on_add())
+        page_header.pack_start(add_btn)
+
+        toolbar_view, _, self._content_box, self._scrolled = make_page_layout(header=page_header)
+
+        self._rebuild_list()
+        return toolbar_view
+
+    # ── List rendering ──
+
+    def _pre_rebuild(self) -> None:
+        self._overridden_external = set()
+        owned_keys = {f"{e.plugin_name}:{e.key}" for e in self._owned}
+        for ext in self._external:
+            unprefixed_key = f"{ext.setting.plugin_name}:{ext.setting.key}"
+            full_key = f"plugin:{unprefixed_key}"
+            state = self._window.app_state.get(full_key)
+            if unprefixed_key in owned_keys or (state is not None and state.managed):
+                self._overridden_external.add(unprefixed_key)
+
+    def _build_empty_state(self) -> EmptyState:
+        return EmptyState(
+            title="No Custom Plugins",
+            description="Add arbitrary settings for unsupported plugins.",
+            icon_name=PLUGINS_ICON,
+        )
+
+    def _build_managed_groups(self) -> list[Gtk.Widget]:
+        groups = []
+        supported = schema.load_plugin_schemas()
+
+        if supported:
+            supported_group = Adw.PreferencesGroup(title="Supported Plugins")
+            for schema_group in supported:
+                row = Adw.ActionRow(
+                    title=schema_group["label"],
+                    subtitle=schema_group.get("description", "Click to configure"),
+                )
+                if "icon" in schema_group:
+                    icon = Gtk.Image.new_from_icon_name(schema_group["icon"])
+                    row.add_prefix(icon)
+                row.set_activatable(True)
+                row.connect(
+                    "activated", lambda _r, g=schema_group: self._show_supported_plugin_dialog(g)
+                )
+                supported_group.add(row)
+            groups.append(supported_group)
+
+        if len(self._owned) > 0:
+            custom = self._build_managed_group("Custom Plugins", range(len(self._owned)))
+            groups.append(custom)
+
+        return groups
+
+    def _show_supported_plugin_dialog(self, schema_group: dict):
+        dialog = Adw.PreferencesDialog()
+        dialog.set_title(f"{schema_group['label']} Settings")
+        dialog.set_content_width(500)
+        dialog.set_content_height(600)
+
+        page = Adw.PreferencesPage(title="")
+        page.set_icon_name(schema_group.get("icon", ""))
+
+        for pref_group in self._window.build_schema_group_widgets(schema_group["id"]):
+            page.add(pref_group)
+
+        dialog.add(page)
+        dialog.present(self._window)
+
+    def _deleted_row_summary(self, item: PluginSetting) -> tuple[str, str]:
+        return f"{item.plugin_name}: {item.key}", item.value or "(empty)"
+
+    # ── Pending-changes summarizers ──
+
+    def _summarize_item(self, item: PluginSetting) -> tuple[str, str]:
+        return f"{item.plugin_name}: {item.key}", item.value or "(empty)"
+
+    def _summarize_modified(self, baseline: PluginSetting, item: PluginSetting) -> tuple[str, str]:
+        if baseline.plugin_name != item.plugin_name or baseline.key != item.key:
+            return (
+                f"{item.plugin_name}: {item.key}",
+                f"{baseline.plugin_name}:{baseline.key} → {item.plugin_name}:{item.key}",
+            )
+        return (
+            f"{item.plugin_name}: {item.key}",
+            f"{baseline.value or '(empty)'} → {item.value or '(empty)'}",
+        )
+
+    def _make_row(self, idx: int, item: PluginSetting) -> Adw.ActionRow:
+        row = Adw.ActionRow(
+            title=html_escape(f"{item.key} = {item.value}"),
+            subtitle=html_escape(f"Plugin: {item.plugin_name}"),
+        )
+        row.set_title_lines(1)
+        row.set_subtitle_lines(1)
+
+        prefix = Gtk.Image.new_from_icon_name(PLUGINS_ICON)
+        prefix.set_opacity(0.6)
+        prefix.set_pixel_size(28)
+        row.add_prefix(prefix)
+
+        self._reorder.attach(row, idx)
+        if idx < len(self._rows_by_idx):
+            self._rows_by_idx[idx] = row
+
+        is_dirty = self._owned.is_item_dirty(idx)
+        is_saved = self._owned.get_baseline(idx) is not None
+
+        actions = RowActions(
+            row,
+            on_discard=lambda i=idx: self._discard_at(i),
+            on_reset=lambda i=idx: self._on_delete_at(i),
+            reset_icon="user-trash-symbolic",
+            reset_tooltip="Remove this setting",
+        )
+        row.add_suffix(actions.box)
+        actions.update(is_managed=True, is_dirty=is_dirty, is_saved=is_saved)
+
+        row.set_activatable(True)
+        row.connect("activated", lambda _r, i=idx: self._on_edit_at(i))
+        row.add_suffix(Gtk.Image.new_from_icon_name("go-next-symbolic"))
+        return row
+
+    def _build_external_hint(self) -> Gtk.Widget:
+        from hyprmod.ui import make_inline_hint
+
+        return make_inline_hint(
+            "Settings below come from your hyprland.conf or its "
+            "sourced files. Click the edit button to override them — "
+            "your managed entry will take precedence on the next "
+            "Hyprland session."
+        )
+
+    def _make_external_row(self, ext: ExternalPluginSetting) -> Adw.ActionRow:
+        key = f"{ext.setting.plugin_name}:{ext.setting.key}"
+        is_overridden = key in self._overridden_external
+        subtitle = f"{ext.setting.value}  ·  line {ext.lineno}"
+
+        row = Adw.ActionRow(
+            title=html_escape(f"Plugin: {ext.setting.plugin_name} · {ext.setting.key}"),
+            subtitle=html_escape(subtitle),
+        )
+        row.set_title_lines(1)
+        row.set_subtitle_lines(1)
+        row.add_css_class("option-default")
+        row.set_opacity(0.65)
+        row.set_tooltip_text(f"{ext.source_path}:{ext.lineno}")
+
+        prefix = Gtk.Image.new_from_icon_name(PLUGINS_ICON)
+        prefix.set_opacity(0.4)
+        prefix.set_pixel_size(28)
+        row.add_prefix(prefix)
+
+        if is_overridden:
+            badge = Gtk.Label(label="Overridden")
+            badge.add_css_class("pending-badge")
+            badge.add_css_class("pending-badge-modified")
+            badge.set_valign(Gtk.Align.CENTER)
+            row.add_suffix(badge)
+            lock_icon = Gtk.Image.new_from_icon_name("changes-prevent-symbolic")
+            lock_icon.set_opacity(0.4)
+            lock_icon.set_valign(Gtk.Align.CENTER)
+            row.add_suffix(lock_icon)
+            return row
+
+        override_btn = Gtk.Button(icon_name="document-edit-symbolic")
+        override_btn.set_valign(Gtk.Align.CENTER)
+        override_btn.add_css_class("flat")
+        override_btn.set_tooltip_text("Override this setting")
+        override_btn.connect("clicked", lambda _b, e=ext: self._on_override(e))
+        row.add_suffix(override_btn)
+
+        lock_icon = Gtk.Image.new_from_icon_name("changes-prevent-symbolic")
+        lock_icon.set_opacity(0.4)
+        lock_icon.set_valign(Gtk.Align.CENTER)
+        row.add_suffix(lock_icon)
+        return row
+
+    def _on_override(self, ext: ExternalPluginSetting) -> None:
+        PluginSettingEditDialog.present_singleton(
+            self._window,
+            entry=ext.setting,
+            on_apply=self._commit_appended,
+        )
+
+    # ── Actions ──
+
+    def _on_add(self) -> None:
+        PluginSettingEditDialog.present_singleton(
+            self._window,
+            on_apply=self._commit_appended,
+        )
+
+    def _on_edit_at(self, idx: int) -> None:
+        if idx < 0 or idx >= len(self._owned):
+            return
+        current = self._owned[idx]
+
+        def on_apply(new_item: PluginSetting) -> None:
+            if new_item != current:
+                self._commit_replaced(idx, new_item)
+
+        PluginSettingEditDialog.present_singleton(
+            self._window,
+            entry=current,
+            on_apply=on_apply,
+        )
+
+    # ── Save Integration ──

--- a/hyprmod/pages/plugins.py
+++ b/hyprmod/pages/plugins.py
@@ -8,6 +8,8 @@ from html import escape as html_escape
 
 from gi.repository import Adw, Gtk
 
+from hyprland_socket import HyprlandError
+
 from hyprmod.core import config, schema
 from hyprmod.core.ownership import SavedList
 from hyprmod.core.plugins import (
@@ -17,7 +19,7 @@ from hyprmod.core.plugins import (
     parse_plugin_options,
 )
 from hyprmod.pages.section import SavedListSectionPage
-from hyprmod.ui import make_page_layout
+from hyprmod.ui import make_page_layout, try_with_toast
 from hyprmod.ui.empty_state import EmptyState
 from hyprmod.ui.icons import PLUGINS_ICON
 from hyprmod.ui.plugin_setting_edit_dialog import PluginSettingEditDialog
@@ -329,28 +331,36 @@ class PluginsPage(SavedListSectionPage[PluginSetting]):
             on_apply=on_apply,
         )
 
+    def _apply_live(self, key: str, value: str) -> None:
+        try_with_toast(
+            self._window.show_bug_toast,
+            "Plugin setting failed",
+            lambda: self._window.hypr.keyword(key, value),
+            catch=HyprlandError,
+        )
+
     def _commit_appended(self, item: PluginSetting) -> None:
         super()._commit_appended(item)
-        self._window.hypr.keyword(f"plugin:{item.plugin_name}:{item.key}", item.value or "")
+        self._apply_live(f"plugin:{item.plugin_name}:{item.key}", item.value or "")
 
     def _commit_replaced(self, idx: int, item: PluginSetting) -> None:
         super()._commit_replaced(idx, item)
-        self._window.hypr.keyword(f"plugin:{item.plugin_name}:{item.key}", item.value or "")
+        self._apply_live(f"plugin:{item.plugin_name}:{item.key}", item.value or "")
 
     def _on_delete_at(self, idx: int) -> None:
         item = self._owned[idx]
         super()._on_delete_at(idx)
-        self._window.hypr.keyword(f"plugin:{item.plugin_name}:{item.key}", "")
+        self._apply_live(f"plugin:{item.plugin_name}:{item.key}", "")
 
     def _discard_at(self, idx: int) -> None:
         item = self._owned[idx]
         baseline = self._owned.get_baseline(idx)
         super()._discard_at(idx)
         value = baseline.value if baseline else ""
-        self._window.hypr.keyword(f"plugin:{item.plugin_name}:{item.key}", value)
+        self._apply_live(f"plugin:{item.plugin_name}:{item.key}", value)
 
     def _on_restore_deleted(self, item: PluginSetting) -> None:
         super()._on_restore_deleted(item)
-        self._window.hypr.keyword(f"plugin:{item.plugin_name}:{item.key}", item.value or "")
+        self._apply_live(f"plugin:{item.plugin_name}:{item.key}", item.value or "")
 
     # ── Save Integration ──

--- a/hyprmod/pages/plugins.py
+++ b/hyprmod/pages/plugins.py
@@ -41,7 +41,6 @@ class PluginsPage(SavedListSectionPage[PluginSetting]):
         window,
         on_dirty_changed=None,
         push_undo=None,
-        saved_sections=None,
     ):
         super().__init__(window, on_dirty_changed, push_undo)
         self._content_box: Gtk.Box
@@ -52,7 +51,7 @@ class PluginsPage(SavedListSectionPage[PluginSetting]):
 
     # ── Loading ──
 
-    def _load(self, saved_sections: dict[str, list[str]] | None = None) -> None:
+    def _load(self) -> None:
         saved_values = self._window.saved_values
         items = parse_plugin_options(saved_values)
 
@@ -128,18 +127,23 @@ class PluginsPage(SavedListSectionPage[PluginSetting]):
                             main_toggle_default = option.get("default", True)
 
                 is_enabled = main_toggle_default
+                status_text = ""
                 if main_toggle_key:
                     state = self._window.app_state.get(main_toggle_key)
                     if state:
-                        is_enabled = bool(state.live_value)
+                        if not state.available:
+                            status_text = "Not installed"
+                        else:
+                            is_enabled = bool(state.live_value)
+
+                if not status_text:
+                    status_text = "Enabled" if is_enabled else "Disabled"
 
                 managed_count = sum(
                     1
                     for k in plugin_keys
                     if (state := self._window.app_state.get(k)) and state.managed
                 )
-
-                status_text = "Enabled" if is_enabled else "Disabled"
                 if managed_count > 0:
                     plural = "s" if managed_count > 1 else ""
                     status_text += f" • {managed_count} custom setting{plural}"
@@ -323,5 +327,29 @@ class PluginsPage(SavedListSectionPage[PluginSetting]):
             entry=current,
             on_apply=on_apply,
         )
+
+    def _commit_appended(self, item: PluginSetting) -> None:
+        super()._commit_appended(item)
+        self._window.hypr.keyword(f"plugin:{item.plugin_name}:{item.key}", item.value or "")
+
+    def _commit_replaced(self, idx: int, item: PluginSetting) -> None:
+        super()._commit_replaced(idx, item)
+        self._window.hypr.keyword(f"plugin:{item.plugin_name}:{item.key}", item.value or "")
+
+    def _on_delete_at(self, idx: int) -> None:
+        item = self._owned[idx]
+        super()._on_delete_at(idx)
+        self._window.hypr.keyword(f"plugin:{item.plugin_name}:{item.key}", "")
+
+    def _discard_at(self, idx: int) -> None:
+        item = self._owned[idx]
+        baseline = self._owned.get_baseline(idx)
+        super()._discard_at(idx)
+        value = baseline.value if baseline else ""
+        self._window.hypr.keyword(f"plugin:{item.plugin_name}:{item.key}", value)
+
+    def _on_restore_deleted(self, item: PluginSetting) -> None:
+        super()._on_restore_deleted(item)
+        self._window.hypr.keyword(f"plugin:{item.plugin_name}:{item.key}", item.value or "")
 
     # ── Save Integration ──

--- a/hyprmod/pages/plugins.py
+++ b/hyprmod/pages/plugins.py
@@ -131,14 +131,15 @@ class PluginsPage(SavedListSectionPage[PluginSetting]):
 
                 is_enabled = main_toggle_default
                 status_text = ""
+                is_loaded = True
                 if main_toggle_key:
                     state = self._window.app_state.get(main_toggle_key)
-                    if state:
-                        if not state.available:
-                            status_text = "Not loaded"
-                            any_not_loaded = True
-                        else:
-                            is_enabled = bool(state.live_value)
+                    if state is None or not state.available:
+                        status_text = "Not loaded"
+                        is_loaded = False
+                        any_not_loaded = True
+                    else:
+                        is_enabled = bool(state.live_value)
 
                 if not status_text:
                     status_text = "Enabled" if is_enabled else "Disabled"
@@ -164,10 +165,13 @@ class PluginsPage(SavedListSectionPage[PluginSetting]):
                 if "icon" in schema_group:
                     icon = Gtk.Image.new_from_icon_name(schema_group["icon"])
                     row.add_prefix(icon)
-                row.set_activatable(True)
-                row.connect(
-                    "activated", lambda _r, g=schema_group: self._show_supported_plugin_dialog(g)
-                )
+
+                row.set_activatable(is_loaded)
+                if is_loaded:
+                    row.connect(
+                        "activated",
+                        lambda _r, g=schema_group: self._show_supported_plugin_dialog(g),
+                    )
                 supported_group.add(row)
             groups.append(supported_group)
 
@@ -179,31 +183,20 @@ class PluginsPage(SavedListSectionPage[PluginSetting]):
             autostart_page = getattr(self._window, "_autostart_page", None)
             if not autostart_page:
                 return True
-            for entry in autostart_page._owned:
-                if entry.keyword == "exec-once" and "hyprpm reload" in (entry.command or ""):
-                    return True
-            for ext in autostart_page._external:
-                ext_cmd = ext.setting.command or ""
-                if ext.setting.keyword == "exec-once" and "hyprpm reload" in ext_cmd:
-                    return True
-            return False
+            return autostart_page.has_command("exec-once", "hyprpm reload")
 
         if any_not_loaded and has_hyprpm and not has_hyprpm_autostart():
-
             def on_add_autostart(_btn) -> None:
                 autostart_page = getattr(self._window, "_autostart_page", None)
                 if autostart_page:
-                    from hyprmod.core.autostart import ExecData
-
-                    data = ExecData(keyword="exec-once", command="hyprpm reload -n")
-                    autostart_page._commit_appended(data)
+                    autostart_page.add_command("exec-once", "hyprpm reload -n")
                     self._rebuild_list()
 
             from hyprmod.ui import make_inline_hint
 
             hint = make_inline_hint(
                 "Plugins must be loaded to configure them. "
-                "Add <code>hyprpm reload</code> to autostart?",
+                "Add hyprpm reload to autostart?",
                 button_label="Add to Autostart",
                 button_callback=on_add_autostart,
             )

--- a/hyprmod/pages/plugins.py
+++ b/hyprmod/pages/plugins.py
@@ -172,6 +172,7 @@ class PluginsPage(SavedListSectionPage[PluginSetting]):
             groups.append(supported_group)
 
         import shutil
+
         has_hyprpm = shutil.which("hyprpm") is not None
 
         def has_hyprpm_autostart() -> bool:
@@ -188,6 +189,7 @@ class PluginsPage(SavedListSectionPage[PluginSetting]):
             return False
 
         if any_not_loaded and has_hyprpm and not has_hyprpm_autostart():
+
             def on_add_autostart(_btn) -> None:
                 autostart_page = getattr(self._window, "_autostart_page", None)
                 if autostart_page:

--- a/hyprmod/pages/plugins.py
+++ b/hyprmod/pages/plugins.py
@@ -186,6 +186,7 @@ class PluginsPage(SavedListSectionPage[PluginSetting]):
             return autostart_page.has_command("exec-once", "hyprpm reload")
 
         if any_not_loaded and has_hyprpm and not has_hyprpm_autostart():
+
             def on_add_autostart(_btn) -> None:
                 autostart_page = getattr(self._window, "_autostart_page", None)
                 if autostart_page:
@@ -195,8 +196,7 @@ class PluginsPage(SavedListSectionPage[PluginSetting]):
             from hyprmod.ui import make_inline_hint
 
             hint = make_inline_hint(
-                "Plugins must be loaded to configure them. "
-                "Add hyprpm reload to autostart?",
+                "Plugins must be loaded to configure them. Add hyprpm reload to autostart?",
                 button_label="Add to Autostart",
                 button_callback=on_add_autostart,
             )

--- a/hyprmod/ui/__init__.py
+++ b/hyprmod/ui/__init__.py
@@ -216,6 +216,8 @@ def make_inline_hint(
     text: str,
     *,
     icon_name: str = "dialog-information-symbolic",
+    button_label: str | None = None,
+    button_callback: Callable[[Gtk.Button], object] | None = None,
 ) -> Gtk.Widget:
     """Build the dim-icon + dim-caption hint row used at the top of list pages.
 
@@ -240,4 +242,13 @@ def make_inline_hint(
     label.add_css_class("dim-label")
     label.add_css_class("caption")
     box.append(label)
+
+    if button_label and button_callback:
+        btn = Gtk.Button(label=button_label)
+        btn.set_valign(Gtk.Align.CENTER)
+        btn.add_css_class("suggested-action")
+        btn.add_css_class("pill")
+        btn.connect("clicked", button_callback)
+        box.append(btn)
+
     return box

--- a/hyprmod/ui/icons.py
+++ b/hyprmod/ui/icons.py
@@ -21,6 +21,7 @@ LAYER_RULES_ICON = "overlapping-windows-symbolic"
 LAYOUTS_ICON = "view-grid-symbolic"
 ANIMATIONS_ICON = "bounce-symbolic"
 CURSOR_ICON = "hyprmod-cursor-symbolic"
+PLUGINS_ICON = "application-x-addon-symbolic"
 
 PENDING_ICON = "view-list-symbolic"
 PROFILES_ICON = "user-bookmarks-symbolic"

--- a/hyprmod/ui/plugin_setting_edit_dialog.py
+++ b/hyprmod/ui/plugin_setting_edit_dialog.py
@@ -1,0 +1,151 @@
+"""Dialog for adding or editing a single plugin setting."""
+
+import re
+from collections.abc import Callable
+
+from gi.repository import Adw, Gtk
+
+from hyprmod.core.plugins import PluginSetting
+from hyprmod.ui import build_preview_group
+from hyprmod.ui.dialog import SingletonDialogMixin
+
+
+class PluginSettingEditDialog(SingletonDialogMixin, Adw.Dialog):
+    """Add/edit dialog for a single plugin setting."""
+
+    def __init__(
+        self,
+        *,
+        entry: PluginSetting | None = None,
+        on_apply: Callable[[PluginSetting], None] | None = None,
+    ):
+        super().__init__()
+        self._is_new = entry is None
+        self._on_apply_callback = on_apply
+
+        if self._is_new:
+            title = "Add Plugin Setting"
+        else:
+            title = "Edit Plugin Setting"
+
+        self.set_title(title)
+        self.set_content_width(540)
+        self.set_content_height(500)
+
+        toolbar = Adw.ToolbarView()
+
+        header = Adw.HeaderBar()
+        cancel_btn = Gtk.Button(label="Cancel")
+        cancel_btn.connect("clicked", lambda _b: self.close())
+        header.pack_start(cancel_btn)
+
+        self._apply_btn = Gtk.Button(label="Apply")
+        self._apply_btn.add_css_class("suggested-action")
+        self._apply_btn.connect("clicked", self._on_apply)
+        self._apply_btn.set_sensitive(False)
+        header.pack_end(self._apply_btn)
+        toolbar.add_top_bar(header)
+
+        content = Gtk.Box(orientation=Gtk.Orientation.VERTICAL, spacing=18)
+        content.set_margin_top(18)
+        content.set_margin_bottom(18)
+        content.set_margin_start(18)
+        content.set_margin_end(18)
+
+        # Variable group
+        var_group = Adw.PreferencesGroup(title="Plugin Setting")
+        var_group.set_description(
+            "Define custom settings for Hyprland plugins. These settings will be written "
+            "into a plugin { ... } block."
+        )
+
+        self._plugin_entry = Adw.EntryRow(title="Plugin Name")
+        self._plugin_entry.set_text(entry.plugin_name if entry else "")
+        self._plugin_entry.connect("changed", self._on_changed)
+        var_group.add(self._plugin_entry)
+
+        self._key_entry = Adw.EntryRow(title="Setting Key")
+        self._key_entry.set_text(entry.key if entry else "")
+        self._key_entry.connect("changed", self._on_changed)
+        var_group.add(self._key_entry)
+
+        self._value_entry = Adw.EntryRow(title="Setting Value")
+        self._value_entry.set_text(entry.value if entry else "")
+        self._value_entry.connect("changed", self._on_changed)
+        self._value_entry.connect("entry-activated", lambda _e: self._on_apply())
+        var_group.add(self._value_entry)
+
+        content.append(var_group)
+
+        self._error_label = Gtk.Label()
+        self._error_label.set_xalign(0)
+        self._error_label.set_wrap(True)
+        self._error_label.add_css_class("error")
+        self._error_label.add_css_class("caption")
+        self._error_label.set_visible(False)
+        content.append(self._error_label)
+
+        preview_group, self._preview_label = build_preview_group()
+        content.append(preview_group)
+
+        toolbar.set_content(content)
+        self.set_child(toolbar)
+
+        if self._is_new:
+            self._plugin_entry.grab_focus()
+        else:
+            self._value_entry.grab_focus()
+
+        self._update_state()
+
+    def _on_changed(self, _entry) -> None:
+        self._update_state()
+
+    def _update_state(self) -> None:
+        plugin_name = self._plugin_entry.get_text().strip()
+        key = self._key_entry.get_text().strip()
+        value = self._value_entry.get_text().strip()
+
+        is_valid = True
+        err_msg = ""
+
+        if not plugin_name:
+            is_valid = False
+            err_msg = "Plugin name cannot be empty."
+        elif not key:
+            is_valid = False
+            err_msg = "Setting key cannot be empty."
+        elif not re.match(r"^[A-Za-z_][A-Za-z0-9_]*$", plugin_name):
+            is_valid = False
+            err_msg = "Plugin name must be a valid identifier."
+        elif not re.match(r"^[A-Za-z_][A-Za-z0-9_]*$", key):
+            is_valid = False
+            err_msg = "Setting key must be a valid identifier."
+
+        if not is_valid and (plugin_name or key):
+            self._error_label.set_text(err_msg)
+            self._error_label.set_visible(True)
+        else:
+            self._error_label.set_visible(False)
+
+        self._apply_btn.set_sensitive(is_valid)
+
+        if is_valid:
+            lines = ["plugin {", f"    {plugin_name} {{", f"        {key} = {value}", "    }", "}"]
+            self._preview_label.set_text("\n".join(lines))
+        else:
+            self._preview_label.set_text("")
+
+    def _on_apply(self, _btn=None) -> None:
+        if not self._apply_btn.get_sensitive():
+            return
+
+        entry = PluginSetting(
+            plugin_name=self._plugin_entry.get_text().strip(),
+            key=self._key_entry.get_text().strip(),
+            value=self._value_entry.get_text().strip(),
+        )
+
+        if self._on_apply_callback:
+            self._on_apply_callback(entry)
+        self.close()

--- a/hyprmod/ui/plugin_setting_edit_dialog.py
+++ b/hyprmod/ui/plugin_setting_edit_dialog.py
@@ -118,7 +118,7 @@ class PluginSettingEditDialog(SingletonDialogMixin, Adw.Dialog):
         elif not re.match(r"^[A-Za-z_][A-Za-z0-9_]*$", plugin_name):
             is_valid = False
             err_msg = "Plugin name must be a valid identifier."
-        elif not re.match(r"^[A-Za-z_][A-Za-z0-9_]*$", key):
+        elif not re.match(r"^[A-Za-z0-9_:-]+$", key):
             is_valid = False
             err_msg = "Setting key must be a valid identifier."
 

--- a/hyprmod/ui/sidebar.py
+++ b/hyprmod/ui/sidebar.py
@@ -11,6 +11,7 @@ from hyprmod.ui.icons import (
     LAYER_RULES_ICON,
     LAYOUTS_ICON,
     MONITORS_ICON,
+    PLUGINS_ICON,
     PROFILES_ICON,
     SETTINGS_ICON,
     WINDOW_RULES_ICON,
@@ -223,6 +224,7 @@ class Sidebar:
         add_schema_row(advanced, "xwayland")
         add_schema_row(advanced, "ecosystem")
         add_schema_row(advanced, "misc")
+        add_row(advanced, "plugins", "Plugin Settings", PLUGINS_ICON)
 
         # Pinned list goes last so select_first() picks schema rows
         self._lists.append(self._pinned_list)

--- a/hyprmod/window.py
+++ b/hyprmod/window.py
@@ -137,7 +137,7 @@ class HyprModWindow(Adw.ApplicationWindow):
         self._load_css()
         self._build_ui()
         self._register_state()
-        if hasattr(self, "_plugins_page"):
+        if self._plugins_page:
             self._plugins_page._rebuild_list()
         self._refresh_all_modified_indicators()
 

--- a/hyprmod/window.py
+++ b/hyprmod/window.py
@@ -1206,7 +1206,7 @@ class HyprModWindow(Adw.ApplicationWindow):
         assert self._plugins_page is not None
         live_options = self.app_state.get_all_live_values()
         supported_plugins = parse_plugin_options(live_options)
-        custom_plugins = list(self._plugins_page._owned)
+        custom_plugins = self._plugins_page.custom_plugins
         sections.plugins = serialize(supported_plugins + custom_plugins)
 
         return sections

--- a/hyprmod/window.py
+++ b/hyprmod/window.py
@@ -577,13 +577,16 @@ class HyprModWindow(Adw.ApplicationWindow):
             result.append(pref_group)
         return result
 
-    def build_schema_group_widgets(self, group_id: str) -> list[Adw.PreferencesGroup]:
-        """Build PreferencesGroup widgets for a schema group by ID.
+    def build_schema_group_widgets(
+        self, group_id_or_dict: str | dict
+    ) -> list[Adw.PreferencesGroup]:
+        """Build PreferencesGroup widgets for a schema group by ID or dictionary."""
+        if isinstance(group_id_or_dict, str):
+            groups = schema.get_groups(self._schema)
+            group = next((g for g in groups if g["id"] == group_id_or_dict), None)
+        else:
+            group = group_id_or_dict
 
-        Used by special pages (e.g. monitors) that embed schema-driven options.
-        """
-        groups = schema.get_groups(self._schema)
-        group = next((g for g in groups if g["id"] == group_id), None)
         if not group:
             return []
         pref_groups = self._build_section_widgets(group)

--- a/hyprmod/window.py
+++ b/hyprmod/window.py
@@ -11,6 +11,7 @@ from hyprland_state import ANIM_LOOKUP, HyprlandState
 
 from hyprmod.core import config, profiles, schema
 from hyprmod.core.bug_report import build_bug_report_url
+from hyprmod.core.plugins import parse_plugin_options, serialize
 from hyprmod.core.settings import apply_saved_config_path, open_settings
 from hyprmod.core.state import AppState
 from hyprmod.core.undo import OptionChange, PairedOptionChange, UndoManager
@@ -391,7 +392,6 @@ class HyprModWindow(Adw.ApplicationWindow):
                 self,
                 on_dirty_changed=self._on_section_dirty,
                 push_undo=self._undo.push,
-                saved_sections=self.saved_sections,
             )
             setattr(self, attr, page)
             self._page_stack.add_named(page.build(header=self._make_page_header(title)), slug)
@@ -1204,12 +1204,12 @@ class HyprModWindow(Adw.ApplicationWindow):
             lambda _p: has_owned_layer_rules,
             lambda p: p.get_layer_rule_lines(),
         )
-        from hyprmod.core.plugins import parse_plugin_options, serialize
-
-        assert self._plugins_page is not None
+        if self._plugins_page is not None:
+            custom_plugins = self._plugins_page.custom_plugins
+        else:
+            custom_plugins = []
         live_options = self.app_state.get_all_live_values()
         supported_plugins = parse_plugin_options(live_options)
-        custom_plugins = self._plugins_page.custom_plugins
         sections.plugins = serialize(supported_plugins + custom_plugins)
 
         return sections
@@ -1292,9 +1292,9 @@ class HyprModWindow(Adw.ApplicationWindow):
         if self._layer_rules_page is not None:
             self._layer_rules_page.reload_from_saved(sections)
 
-        if self._workspaces_page is not None:
+        if self._workspaces_page:
             self._workspaces_page.reload_from_saved(sections)
-        if self._plugins_page is not None:
+        if self._plugins_page:
             self._plugins_page.reload_from_saved(sections)
 
         self._undo.clear()

--- a/hyprmod/window.py
+++ b/hyprmod/window.py
@@ -1215,12 +1215,6 @@ class HyprModWindow(Adw.ApplicationWindow):
         return sections
 
     def _perform_save(self, *, update_active_profile: bool = True):
-        assert self._plugins_page is not None
-        plugins_changed = (
-            any(k.startswith("plugin:") for k in self.app_state.get_dirty_values())
-            or self._plugins_page.is_dirty()
-        )
-
         # ``write_all`` invalidates ``config.read_cached`` internally, so any
         # subsequent ``saved_sections`` access reflects what we just wrote.
         config.write_all(
@@ -1229,9 +1223,6 @@ class HyprModWindow(Adw.ApplicationWindow):
             hyprland_version=self.hypr.version,
         )
         self.app_state.mark_saved()
-
-        if plugins_changed:
-            self.hypr.reload_compositor()
 
         self.hypr.clear_pending()
         for section in self._section_pages:
@@ -1301,9 +1292,9 @@ class HyprModWindow(Adw.ApplicationWindow):
         if self._layer_rules_page is not None:
             self._layer_rules_page.reload_from_saved(sections)
 
-        if self._workspaces_page:
+        if self._workspaces_page is not None:
             self._workspaces_page.reload_from_saved(sections)
-        if self._plugins_page:
+        if self._plugins_page is not None:
             self._plugins_page.reload_from_saved(sections)
 
         self._undo.clear()

--- a/hyprmod/window.py
+++ b/hyprmod/window.py
@@ -24,6 +24,7 @@ from hyprmod.pages.layer_rules import LayerRulesPage
 from hyprmod.pages.layouts import LayoutsPage
 from hyprmod.pages.monitors import MonitorsPage
 from hyprmod.pages.pending import PendingChangesPage
+from hyprmod.pages.plugins import PluginsPage
 from hyprmod.pages.profiles import ProfilesPage
 from hyprmod.pages.section import SectionPage
 from hyprmod.pages.settings import SettingsPage
@@ -92,6 +93,12 @@ class HyprModWindow(Adw.ApplicationWindow):
             self._schema["groups"] = [
                 g for g in schema.get_groups(self._schema) if g["id"] != GESTURES
             ]
+
+        # Append plugin schemas (hidden from main sidebar so they only show in PluginsPage)
+        for plugin_group in schema.load_plugin_schemas():
+            plugin_group["hidden"] = True
+            self._schema["groups"].append(plugin_group)
+
         self.app_state = AppState(self.hypr)
         self._option_rows: dict[str, OptionRow] = {}
         # Track the PreferencesGroup that owns each option row so we can hide
@@ -118,6 +125,7 @@ class HyprModWindow(Adw.ApplicationWindow):
         self._layouts_page: LayoutsPage | None = None
         self._profiles_page: ProfilesPage | None = None
         self._settings_page: SettingsPage | None = None
+        self._plugins_page: PluginsPage | None = None
         self._pending_page: PendingChangesPage | None = None
         self._pre_search_page_id: str | None = None
         self._search_results: list | None = None
@@ -308,6 +316,7 @@ class HyprModWindow(Adw.ApplicationWindow):
                 self._env_vars_page,
                 self._window_rules_page,
                 self._layer_rules_page,
+                self._plugins_page,
             )
             if p is not None
         ]
@@ -375,6 +384,7 @@ class HyprModWindow(Adw.ApplicationWindow):
             (EnvVarsPage, "_env_vars_page", "env_vars", "Env Variables"),
             (WindowRulesPage, "_window_rules_page", "window_rules", "Window Rules"),
             (LayerRulesPage, "_layer_rules_page", "layer_rules", "Layer Rules"),
+            (PluginsPage, "_plugins_page", "plugins", "Plugin Settings"),
         ]
         for cls, attr, slug, title in section_page_specs:
             page = cls(
@@ -1191,10 +1201,23 @@ class HyprModWindow(Adw.ApplicationWindow):
             lambda _p: has_owned_layer_rules,
             lambda p: p.get_layer_rule_lines(),
         )
+        from hyprmod.core.plugins import parse_plugin_options, serialize
+
+        assert self._plugins_page is not None
+        live_options = self.app_state.get_all_live_values()
+        supported_plugins = parse_plugin_options(live_options)
+        custom_plugins = list(self._plugins_page._owned)
+        sections.plugins = serialize(supported_plugins + custom_plugins)
 
         return sections
 
     def _perform_save(self, *, update_active_profile: bool = True):
+        assert self._plugins_page is not None
+        plugins_changed = (
+            any(k.startswith("plugin:") for k in self.app_state.get_dirty_values())
+            or self._plugins_page.is_dirty()
+        )
+
         # ``write_all`` invalidates ``config.read_cached`` internally, so any
         # subsequent ``saved_sections`` access reflects what we just wrote.
         config.write_all(
@@ -1203,6 +1226,10 @@ class HyprModWindow(Adw.ApplicationWindow):
             hyprland_version=self.hypr.version,
         )
         self.app_state.mark_saved()
+
+        if plugins_changed:
+            self.hypr.reload_compositor()
+
         self.hypr.clear_pending()
         for section in self._section_pages:
             section.mark_saved()
@@ -1271,8 +1298,10 @@ class HyprModWindow(Adw.ApplicationWindow):
         if self._layer_rules_page is not None:
             self._layer_rules_page.reload_from_saved(sections)
 
-        if self._workspaces_page is not None:
+        if self._workspaces_page:
             self._workspaces_page.reload_from_saved(sections)
+        if self._plugins_page:
+            self._plugins_page.reload_from_saved(sections)
 
         self._undo.clear()
         self._banner.hide()

--- a/hyprmod/window.py
+++ b/hyprmod/window.py
@@ -137,6 +137,8 @@ class HyprModWindow(Adw.ApplicationWindow):
         self._load_css()
         self._build_ui()
         self._register_state()
+        if hasattr(self, "_plugins_page"):
+            self._plugins_page._rebuild_list()
         self._refresh_all_modified_indicators()
 
     @property

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,7 @@ license = "GPL-3.0-or-later"
 requires-python = ">=3.12"
 dependencies = [
     "pygobject>=3.56.2",
-    "hyprland-config>=0.9.10",
+    "hyprland-config>=0.9.11",
     "hyprland-schema>=0.6.3",
     "hyprland-state>=0.4.3",
     "hyprland-monitors>=0.8.0",

--- a/tests/test_plugins.py
+++ b/tests/test_plugins.py
@@ -1,0 +1,122 @@
+"""Tests for plugin options parsing, serialization, and config integration."""
+
+from hyprmod.core.plugins import (
+    PluginSetting,
+    load_external_plugins,
+    parse_plugin_options,
+    serialize,
+)
+
+
+class TestPluginSetting:
+    def test_to_line(self):
+        setting = PluginSetting("dynamic-cursors", "mode", "stretch")
+        assert setting.to_line() == "mode = stretch"
+
+
+class TestParsePluginOptions:
+    def test_basic_parsing(self):
+        options = {
+            "plugin:dynamic-cursors:mode": "stretch",
+            "plugin:dynamic-cursors:threshold": "2",
+            "misc:vfr": "true",
+            "plugin:other:enabled": "false",
+        }
+        result = parse_plugin_options(options)
+        assert len(result) == 3
+        assert result[0] == PluginSetting("dynamic-cursors", "mode", "stretch")
+        assert result[1] == PluginSetting("dynamic-cursors", "threshold", "2")
+        assert result[2] == PluginSetting("other", "enabled", "false")
+
+    def test_ignores_non_plugin_keys(self):
+        options = {
+            "general:border_size": "2",
+            "decoration:rounding": "10",
+        }
+        assert parse_plugin_options(options) == []
+
+    def test_ignores_malformed_plugin_keys(self):
+        options = {
+            "plugin:": "test",
+            "plugin:name": "test",
+        }
+        assert parse_plugin_options(options) == []
+
+
+class TestSerialize:
+    def test_basic_serialization(self):
+        settings = [
+            PluginSetting("dynamic-cursors", "mode", "stretch"),
+            PluginSetting("dynamic-cursors", "threshold", "2"),
+            PluginSetting("other", "enabled", "false"),
+        ]
+        result = serialize(settings)
+        expected = [
+            "plugin {\n",
+            "  dynamic-cursors {\n",
+            "    mode = stretch\n",
+            "    threshold = 2\n",
+            "  }\n",
+            "}\n",
+            "plugin {\n",
+            "  other {\n",
+            "    enabled = false\n",
+            "  }\n",
+            "}\n",
+        ]
+        assert result == expected
+
+    def test_empty_serialization(self):
+        assert serialize([]) == []
+
+
+class TestLoadExternalPlugins:
+    def test_loads_external_plugin_settings(self, tmp_path):
+        managed_path = tmp_path / "hyprmod.conf"
+        managed_path.write_text("plugin { \n dynamic-cursors { mode = none } \n }")
+
+        main_path = tmp_path / "hyprland.conf"
+        main_path.write_text(
+            f"""
+source = {managed_path.absolute()}
+plugin {{
+    dynamic-cursors {{
+        mode = stretch
+        threshold = 2
+    }}
+    other {{
+        enabled = true
+    }}
+}}
+"""
+        )
+
+        external = load_external_plugins(main_path, managed_path)
+
+        assert len(external) == 3
+
+        assert external[0].setting == PluginSetting("dynamic-cursors", "mode", "stretch")
+        assert external[0].source_path.resolve() == main_path.resolve()
+        assert external[0].lineno == 5
+
+        assert external[1].setting == PluginSetting("dynamic-cursors", "threshold", "2")
+        assert external[1].lineno == 6
+
+        assert external[2].setting == PluginSetting("other", "enabled", "true")
+        assert external[2].lineno == 9
+
+    def test_ignores_managed_path(self, tmp_path):
+        managed_path = tmp_path / "hyprmod.conf"
+        managed_path.write_text("plugin { \n dynamic-cursors { mode = none } \n }")
+        main_path = tmp_path / "hyprland.conf"
+        main_path.write_text(f"source = {managed_path.absolute()}")
+
+        external = load_external_plugins(main_path, managed_path)
+        assert len(external) == 0
+
+    def test_returns_empty_when_root_path_not_exists(self, tmp_path):
+        main_path = tmp_path / "hyprland.conf"
+        managed_path = tmp_path / "hyprmod.conf"
+
+        external = load_external_plugins(main_path, managed_path)
+        assert len(external) == 0

--- a/uv.lock
+++ b/uv.lock
@@ -13,11 +13,11 @@ wheels = [
 
 [[package]]
 name = "hyprland-config"
-version = "0.9.10"
+version = "0.9.11"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/53/f8/b97913894e7bf378a146d9ceb1db1782cffb16b090000625577707209752/hyprland_config-0.9.10.tar.gz", hash = "sha256:a4057a324854ca6f8c627f1e1af9a0546139cca878b5e2295e71061bbb2cafe4", size = 101868, upload-time = "2026-06-29T09:05:44.493Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/a1/61/4a3a374ac6f25d92516afd7336af7ccc2c914aad604554a82fd552eeb260/hyprland_config-0.9.11.tar.gz", hash = "sha256:e9c87c8607aaa290522cd625f62ba4b1d827184d2923503217e74ecc3cafa92c", size = 102108, upload-time = "2026-07-05T05:26:21.352Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/ba/5d/3765f553e1f73a6ff11c3d572682c9bfbf630b3b87dbe20f738535a858a3/hyprland_config-0.9.10-py3-none-any.whl", hash = "sha256:1cc0fcd4bcee53fd763bfc815d8c3af8209a23b425effeacc7a859dff25587e3", size = 125159, upload-time = "2026-06-29T09:05:42.61Z" },
+    { url = "https://files.pythonhosted.org/packages/d7/25/51b31ae53366c394123649f478e1136208f8b7b1f5e0778792a3dda8b5a5/hyprland_config-0.9.11-py3-none-any.whl", hash = "sha256:c75c994d32abf930f86e8c2cf861f22a2b9260ba585afc363771c8b8a4a9c150", size = 125403, upload-time = "2026-07-05T05:26:19.876Z" },
 ]
 
 [[package]]
@@ -88,7 +88,7 @@ dev = [
 
 [package.metadata]
 requires-dist = [
-    { name = "hyprland-config", specifier = ">=0.9.10" },
+    { name = "hyprland-config", specifier = ">=0.9.11" },
     { name = "hyprland-monitors", specifier = ">=0.8.0" },
     { name = "hyprland-schema", specifier = ">=0.6.3" },
     { name = "hyprland-socket", specifier = ">=0.12.2" },


### PR DESCRIPTION
Add native support for managing Hyprland plugins in HyprMod.

- Introduces a new Plugins page for managing both custom plugin configurations and supported plugin schemas.
- Implements `plugin { ... }` block serialization for Lua configs.
- Adds schema loading and UI generation for natively supported plugins, starting with **Hypr Dynamic Cursors**.
- Selectively reloads the compositor on save when plugin settings are modified, bypassing IPC keyword failures for non-legacy parsers.
- Implements contextual UI hints to guide users in adding `hyprpm reload` to their autostart configuration when plugins are not loaded.

#59 