### PR TITLE
Add "Pick from installed apps" to keybind Run command field

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Plugins page for configuring Hyprland plugins: a schema-driven UI for natively supported plugins (starting with Hypr Dynamic Cursors) plus a list editor for arbitrary `plugin { … }` settings, with live-apply, detection of plugin settings from your existing config, and a prompt to add `hyprpm reload` to autostart when a supported plugin is not loaded (#60)
 - The window rule dialog supports multiple actions per rule: actions are a dynamic list of blocks that can be added and removed individually, instead of a single action per rule; anonymous rules with multiple effects now also load as one rule instead of splitting into separate entries (#57, #58)
+- The keybind dialog's "Run command" action can pick from installed apps: a search button next to the Command field opens the same app picker used by autostart entries, filling the field with the selected app's command
 
 ### Changed
 

--- a/hyprmod/binds/dialog.py
+++ b/hyprmod/binds/dialog.py
@@ -24,7 +24,9 @@ from hyprmod.binds.gdk_modifiers import (
     keysyms_to_mods,
     unshifted_keyval,
 )
+from hyprmod.core.desktop_apps import DesktopApp
 from hyprmod.ui import clear_children, confirm
+from hyprmod.ui.app_picker import AppPickerDialog
 
 log = logging.getLogger(__name__)
 
@@ -124,6 +126,22 @@ def _build_arg_widget(arg_type: str, current_value: str):
     if arg_type == "command":
         row = Adw.EntryRow(title="Command")
         row.set_text(current_value)
+
+        def on_pick(app: DesktopApp) -> None:
+            row.set_text(app.command)
+            # Restore focus to the entry so the auto-filled command can be
+            # edited (e.g. to add args) without an extra click.
+            row.grab_focus()
+
+        pick_btn = Gtk.Button.new_from_icon_name("system-search-symbolic")
+        pick_btn.set_valign(Gtk.Align.CENTER)
+        pick_btn.add_css_class("flat")
+        pick_btn.set_tooltip_text("Pick from installed apps")
+        pick_btn.connect(
+            "clicked", lambda _b: AppPickerDialog.present_singleton(row, on_pick=on_pick)
+        )
+        row.add_suffix(pick_btn)
+
         return row, lambda: row.get_text().strip()
 
     if arg_type == "workspace":


### PR DESCRIPTION
The "Run command" / "Run raw command" keybind actions now show a search button next to the Command field that opens the installed-apps picker, reusing the same AppPickerDialog as the autostart entry dialog. Picking an app fills the field with its command and restores focus for editing.