### PR TITLE
fix: use absolute path for desktop entry Exec to prevent launch failures

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,6 +78,14 @@ To uninstall:
 curl -LsSf https://raw.githubusercontent.com/BlueManCZ/hyprmod/main/install.sh | sh -s -- --uninstall
 ```
 
+### 📦 pkgit
+
+If you use `pkgit`, you can install `hyprmod` with:
+
+```bash
+pkgit -i https://github.com/BlueManCZ/hyprmod
+```
+
 ### Distribution packages
 
 **Arch Linux** — [`hyprmod`](https://aur.archlinux.org/packages/hyprmod) on the AUR:

--- a/README.md
+++ b/README.md
@@ -80,7 +80,7 @@ curl -LsSf https://raw.githubusercontent.com/BlueManCZ/hyprmod/main/install.sh |
 
 ### 📦 pkgit
 
-If you use `pkgit`, you can install `hyprmod` with:
+If you use [`pkgit`](https://git.symlinx.net/pkgit/about/), you can install `hyprmod` directly with:
 
 ```bash
 pkgit -i https://github.com/BlueManCZ/hyprmod

--- a/bldit.lua
+++ b/bldit.lua
@@ -1,42 +1,40 @@
 bldit_version = "0.1.3"
-package_name = "hyprmod"
-package_version = "0.4.0"
-global_dependencies = {}
 dependencies = {}
 
 targets = {
     default = {
+        -- install.sh builds + installs; pkgit still needs a build step to exist.
         build = function()
-            os.execute("rm -rf dist")
-            os.execute("python -m build --wheel")
             return 0
         end,
         install = function()
-            os.execute("sudo python -m installer --overwrite-existing dist/*.whl")
-            os.execute("hyprmod --install")
-            return 0
+            return os.execute(
+                "UV_TOOL_BIN_DIR='" .. prefix .. "/bin' PIPX_BIN_DIR='" .. prefix .. "/bin' "
+                .. "HYPRMOD_SOURCE=. sh install.sh"
+            )
         end,
         uninstall = function()
-            os.execute("hyprmod --uninstall")
-            os.execute("sudo rm -f /usr/local/bin/hyprmod /usr/bin/hyprmod")
-            return 0
-        end
+            return os.execute(
+                "UV_TOOL_BIN_DIR='" .. prefix .. "/bin' PIPX_BIN_DIR='" .. prefix .. "/bin' "
+                .. "sh install.sh --uninstall"
+            )
+        end,
     },
     quiet = {
         build = function()
-            os.execute("rm -rf dist >/dev/null 2>&1")
-            os.execute("python -m build --wheel >/dev/null 2>&1")
             return 0
         end,
         install = function()
-            os.execute("sudo python -m installer --overwrite-existing dist/*.whl >/dev/null 2>&1")
-            os.execute("hyprmod --install >/dev/null 2>&1")
-            return 0
+            return os.execute(
+                "UV_TOOL_BIN_DIR='" .. prefix .. "/bin' PIPX_BIN_DIR='" .. prefix .. "/bin' "
+                .. "HYPRMOD_SOURCE=. sh install.sh >/dev/null 2>&1"
+            )
         end,
         uninstall = function()
-            os.execute("hyprmod --uninstall >/dev/null 2>&1")
-            os.execute("sudo rm -f /usr/local/bin/hyprmod /usr/bin/hyprmod >/dev/null 2>&1")
-            return 0
-        end
-    }
+            return os.execute(
+                "UV_TOOL_BIN_DIR='" .. prefix .. "/bin' PIPX_BIN_DIR='" .. prefix .. "/bin' "
+                .. "sh install.sh --uninstall >/dev/null 2>&1"
+            )
+        end,
+    },
 }

--- a/bldit.lua
+++ b/bldit.lua
@@ -1,0 +1,42 @@
+bldit_version = "0.1.3"
+package_name = "hyprmod"
+package_version = "1.0.0"
+global_dependencies = {}
+dependencies = {}
+
+targets = {
+    default = {
+        build = function()
+            os.execute("rm -rf dist")
+            os.execute("python -m build --wheel")
+            return 0
+        end,
+        install = function()
+            os.execute("sudo python -m installer --overwrite-existing dist/*.whl")
+            os.execute("hyprmod --install")
+            return 0
+        end,
+        uninstall = function()
+            os.execute("hyprmod --uninstall")
+            os.execute("sudo rm -f /usr/local/bin/hyprmod /usr/bin/hyprmod")
+            return 0
+        end
+    },
+    quiet = {
+        build = function()
+            os.execute("rm -rf dist >/dev/null 2>&1")
+            os.execute("python -m build --wheel >/dev/null 2>&1")
+            return 0
+        end,
+        install = function()
+            os.execute("sudo python -m installer --overwrite-existing dist/*.whl >/dev/null 2>&1")
+            os.execute("hyprmod --install >/dev/null 2>&1")
+            return 0
+        end,
+        uninstall = function()
+            os.execute("hyprmod --uninstall >/dev/null 2>&1")
+            os.execute("sudo rm -f /usr/local/bin/hyprmod /usr/bin/hyprmod >/dev/null 2>&1")
+            return 0
+        end
+    }
+}

--- a/bldit.lua
+++ b/bldit.lua
@@ -1,6 +1,6 @@
 bldit_version = "0.1.3"
 package_name = "hyprmod"
-package_version = "1.0.0"
+package_version = "0.4.0"
 global_dependencies = {}
 dependencies = {}
 

--- a/install.sh
+++ b/install.sh
@@ -105,6 +105,14 @@ do_install() {
     echo '>> Registering desktop entry and icon...'
     hyprmod --install
 
+    # Fix Exec path to be absolute so it works in GUI environments that don't source ~/.local/bin
+    if have hyprmod; then
+        DESKTOP_FILE="${XDG_DATA_HOME:-$HOME/.local/share}/applications/io.github.bluemancz.hyprmod.desktop"
+        if [ -f "$DESKTOP_FILE" ]; then
+            sed -i "s|^Exec=hyprmod$|Exec=$(command -v hyprmod)|" "$DESKTOP_FILE"
+        fi
+    fi
+
     echo
     echo '>> Done. Launch HyprMod from your app menu or run: hyprmod'
 }


### PR DESCRIPTION
### Description
This PR fixes an issue where `hyprmod` fails to launch from GUI app launchers and docks (like Quickshell) when installed via `uv` or `pipx`.

Currently, `hyprmod --install` generates a `.desktop` file with `Exec=hyprmod`. However, GUI environments and Wayland compositors often don't inherit `~/.local/bin` in their `$PATH` unless explicitly sourced. As a result, the launcher silently fails to find the `hyprmod` executable.

To fix this, the `install.sh` script now explicitly updates the `Exec` path in the generated `.desktop` file to use the absolute path of the `hyprmod` binary.

### Changes
* Modified `install.sh` to rewrite `Exec=hyprmod` to `Exec=/absolute/path/to/hyprmod` in the `.desktop` file immediately after it is registered.