### PR TITLE
Record bind keys the way Hyprland resolves them

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Recording a media, brightness, or other `XF86` key in the keybind dialog no longer produces a bind Hyprland rejects with "Unknown keysym"; GDK reports these keysyms without their `XF86` prefix (`AudioRaiseVolume`), which is not a name xkb resolves, so the prefix is now restored before the key reaches the config (#69)
+- Recording a shortcut whose key sits on a shifted or AltGr level no longer produces a bind that never fires; Hyprland matches binds against the base-level keysym, so the captured key is now resolved with every modifier cleared instead of only `SHIFT`, fixing AltGr+Q on a Czech layout being recorded as `MOD5, backslash` where Hyprland only ever looks for `q` (#69)
+- Recording a shortcut while a secondary keyboard layout is active no longer produces a bind that never fires; unless `resolve_binds_by_sym` is set, Hyprland resolves binds through the first layout in `input:kb_layout` regardless of which one is active, so on `cz,us` the number row key recorded as `2` from the us layout is now recorded as `ecaron` (#73)
 - Window rules with multiple effects no longer lose every effect after the first when saved in Lua mode; rule lines are now normalized so the Lua serializer emits all effects (#60)
 - Changing a condition from a boolean type (like `xwayland`) to a text type (like `initial_class`) no longer leaves the literal string `"false"` in the value field (#56)
 

--- a/hyprmod/binds/dialog.py
+++ b/hyprmod/binds/dialog.py
@@ -21,8 +21,9 @@ from hyprmod.binds.dispatchers import (
 )
 from hyprmod.binds.gdk_modifiers import (
     MODIFIER_KEYVALS,
+    base_keyval,
+    keysym_name,
     keysyms_to_mods,
-    unshifted_keyval,
 )
 from hyprmod.core.desktop_apps import DesktopApp
 from hyprmod.ui import clear_children, confirm
@@ -615,8 +616,8 @@ class BindEditDialog(Adw.Dialog):
             except HyprlandError as e:
                 log.error("could not reset Hyprland submap after capture; user may be stuck: %s", e)
 
-    def _on_key_captured(self, controller, keyval, keycode, state):
-        key_name = Gdk.keyval_name(keyval)
+    def _on_key_captured(self, controller, keyval, keycode, _state):
+        key_name = keysym_name(keyval)
         if not key_name:
             return True
         if key_name == "Escape":
@@ -635,14 +636,16 @@ class BindEditDialog(Adw.Dialog):
             # via Shift+letter combos without losing capture.
             return True
         mods = keysyms_to_mods(self._held_modifiers)
-        if state & Gdk.ModifierType.SHIFT_MASK:
-            widget = controller.get_widget()
-            display = widget.get_display() if widget is not None else None
-            if display is not None:
-                kv = unshifted_keyval(display, keycode, state, controller.get_group(), keyval)
-                resolved = Gdk.keyval_name(kv)
-                if resolved and resolved not in MODIFIER_KEYVALS:
-                    key_name = resolved
+        widget = controller.get_widget()
+        display = widget.get_display() if widget is not None else None
+        if display is not None:
+            kv = base_keyval(display, keycode, self._bind_layout_group(controller), keyval)
+            resolved = keysym_name(kv)
+            # A key whose base level is itself a modifier (a layout where
+            # AltGr+X reaches a real symbol over an ISO_Level3_Shift) would
+            # otherwise be recorded as a bind key Hyprland can't trigger.
+            if resolved and resolved not in MODIFIER_KEYVALS:
+                key_name = resolved
         display_key = key_name.upper() if len(key_name) == 1 else key_name
         for mod_name, switch in self._mod_checks.items():
             switch.set_active(mod_name in mods)
@@ -650,6 +653,19 @@ class BindEditDialog(Adw.Dialog):
         self._update_capture_display()
         self._stop_capture()
         return True
+
+    def _bind_layout_group(self, controller) -> int:
+        """Return the keymap group Hyprland will resolve this bind through.
+
+        By default Hyprland translates key events for bind lookup through a
+        state built from ``input:kb_layout`` that never gets a group update,
+        so the first layout wins whatever the user has active: on ``cz,us``
+        the number row is ``ecaron``, ``scaron``, … even while typing in us.
+        Only ``resolve_binds_by_sym`` follows the active group.
+        """
+        if self._window.hypr.get("input:resolve_binds_by_sym", False):
+            return controller.get_group()
+        return 0
 
     def _on_key_released(self, _controller, keyval, _keycode, _state):
         key_name = Gdk.keyval_name(keyval)

--- a/hyprmod/binds/gdk_modifiers.py
+++ b/hyprmod/binds/gdk_modifiers.py
@@ -26,6 +26,40 @@ MODIFIER_KEYVALS: frozenset[str] = frozenset(
 )
 
 
+# Bounds of the vendor keysym block (``XF86XK_*`` in X11's keysymdef), the
+# only range where GDK's spelling of a keysym differs from xkb's.
+_XF86_KEYVAL_MIN = 0x10080000
+_XF86_KEYVAL_MAX = 0x1008FFFF
+
+# The two vendor keysyms GDK names after their pre-xkb spelling, where
+# restoring the prefix alone would not reach a name xkb knows.
+_GDK_LEGACY_KEYSYM_NAMES = {
+    "WindowClear": "XF86Clear",
+    "SelectButton": "XF86Select",
+}
+
+
+def keysym_name(keyval: int) -> str | None:
+    """Return *keyval*'s keysym name in the spelling Hyprland parses.
+
+    GDK's generator strips the ``XF86`` prefix off the vendor block, so
+    ``Gdk.keyval_name`` answers ``AudioRaiseVolume`` where xkb (and with it
+    Hyprland's ``xkb_keysym_from_name``) resolves only
+    ``XF86AudioRaiseVolume``. Handing Hyprland the GDK spelling gets the
+    whole bind rejected with "Unknown keysym".
+
+    ``None`` for a keyval GDK cannot name at all.
+    """
+    name = Gdk.keyval_name(keyval)
+    if name is None or not _XF86_KEYVAL_MIN <= keyval <= _XF86_KEYVAL_MAX:
+        return name
+    # Vendor keysyms GDK has no name for come back as a "0x..." literal,
+    # which xkb accepts verbatim. Prefixing one would break it.
+    if name.startswith("0x"):
+        return name
+    return _GDK_LEGACY_KEYSYM_NAMES.get(name, f"XF86{name}")
+
+
 def keysyms_to_mods(held: set[str]) -> list[str]:
     """Return canonical Hyprland modifier names for the held modifier keysyms.
 
@@ -35,21 +69,21 @@ def keysyms_to_mods(held: set[str]) -> list[str]:
     return [name for name, ks in MOD_NAME_TO_KEYSYMS.items() if held & ks]
 
 
-def unshifted_keyval(
+def base_keyval(
     display: Gdk.Display,
     keycode: int,
-    state: Gdk.ModifierType,
     group: int,
     fallback: int,
 ) -> int:
-    """Resolve the keyval the keycode would produce without SHIFT.
+    """Resolve the keyval the keycode produces with no modifier applied.
 
-    Hyprland binds use the unshifted keysym when ``SHIFT`` is in the modifier
-    mask (e.g. ``SUPER SHIFT, 1`` rather than ``SUPER SHIFT, exclam`` on US,
-    or ``SUPER SHIFT, plus`` on Czech). GDK already applied shift to give us
-    the level-1+ symbol, so re-translate the keycode with shift cleared.
-    Other modifiers (AltGr/level3) are preserved so layered layouts still get
-    the right keysym.
+    Hyprland matches binds against the base-level keysym: the xkb state it
+    translates key events through for bind lookup is created fresh and never
+    receives a modifier mask, so Shift, AltGr and every other level chooser
+    are ignored. A bind recorded from the modified keysym (``SUPER SHIFT,
+    exclam`` on US, ``MOD5, backslash`` for AltGr+Q on Czech) can never fire.
+    GDK hands us the modified keyval, so re-translate the keycode from
+    scratch.
     """
-    ok, kv, *_ = display.translate_key(keycode, state & ~Gdk.ModifierType.SHIFT_MASK, group)
+    ok, kv, *_ = display.translate_key(keycode, Gdk.ModifierType(0), group)
     return kv if ok and kv else fallback

--- a/tests/test_binds.py
+++ b/tests/test_binds.py
@@ -22,6 +22,7 @@ from hyprmod.binds import (
     format_bind_action,
     live_bind_to_data,
 )
+from hyprmod.binds.gdk_modifiers import keysym_name
 
 # ---------------------------------------------------------------------------
 # Helpers
@@ -797,3 +798,39 @@ class TestBindEditDialog:
         )
         d = self._dialog(bind=existing)
         assert d.get_bind().key == "mouse:280"
+
+
+# ---------------------------------------------------------------------------
+
+
+class TestKeysymName:
+    """Captured keysyms must be spelled the way Hyprland's xkb lookup expects.
+
+    ``Gdk.keyval_name`` drops the ``XF86`` prefix from every vendor keysym,
+    and Hyprland rejects the whole bind with "Unknown keysym" when it gets
+    the GDK spelling.
+    """
+
+    def test_media_keys_keep_their_xf86_prefix(self):
+        assert keysym_name(0x1008FF13) == "XF86AudioRaiseVolume"
+        assert keysym_name(0x1008FF02) == "XF86MonBrightnessUp"
+
+    def test_vt_switch_keeps_its_xf86_prefix(self):
+        # The keysym from issue #69: Ctrl+Alt+F12 resolves to the VT switch.
+        assert keysym_name(0x1008FE0C) == "XF86Switch_VT_12"
+
+    def test_legacy_gdk_names_map_to_their_xkb_spelling(self):
+        # GDK names these two after their pre-xkb spelling (``WindowClear``,
+        # ``SelectButton``), so restoring the prefix alone would still leave
+        # xkb without a match.
+        assert keysym_name(0x1008FF55) == "XF86Clear"
+        assert keysym_name(0x1008FFA0) == "XF86Select"
+
+    def test_unnamed_vendor_keysyms_stay_hex(self):
+        # GDK falls back to a "0x..." literal, which xkb parses as-is.
+        assert keysym_name(0x1008FFFE) == "0x1008fffe"
+
+    def test_ordinary_keysyms_are_untouched(self):
+        assert keysym_name(0xFFC9) == "F12"
+        assert keysym_name(0xFF0D) == "Return"
+        assert keysym_name(0x0061) == "a"


### PR DESCRIPTION
Fixes #69.

The keybind dialog captured keysyms straight from GDK, in three ways Hyprland cannot match.

**`XF86` prefix.** GDK names the vendor block without it (`AudioRaiseVolume`), which `xkb_keysym_from_name` does not resolve, so every media and brightness key was rejected with "Unknown keysym".

**Base-level keysym.** Hyprland's bind lookup translates key events through an xkb state that never receives a modifier mask. Clearing only `SHIFT` left AltGr applied, so AltGr+Q on a Czech layout was recorded as `MOD5, backslash` where Hyprland only looks for `q`. It also turned Shift+Ctrl+Alt+F12 into `XF86Switch_VT_12` by stripping Shift and leaving Ctrl+Alt, which is the issue as reported.

**Layout group.** Not part of #69, found while fixing the other two and in the same code path. Unless `resolve_binds_by_sym` is set, that state stays on group 0 of `input:kb_layout`, so a key recorded while a secondary layout was active never fired. On `cz,us` the number row is `ecaron`, `scaron`, ... even while typing in us.

## Verified

Against a live Hyprland 0.55.4 in Lua mode, `cz,us` layout:

- Every GDK spelling is rejected by the compositor, every corrected spelling registers.
- With `MOD5, q` and `MOD5, backslash` both bound, AltGr+Q fired `MOD5, q`, confirming base-level matching.
- In the app: AltGr+Q now records `MOD5 + Q`, the number row records `ecaron` in both layouts, and Shift+Ctrl+Alt+F12 binds and fires.