### PR TITLE
nix: bump inline hyprland-config to 0.9.13

### DIFF
--- a/nix/hyprmod.nix
+++ b/nix/hyprmod.nix
@@ -35,13 +35,13 @@ let
 
   hyprland-config = python3Packages.buildPythonPackage rec {
     pname = "hyprland-config";
-    version = "0.9.12";
+    version = "0.9.13";
     pyproject = true;
     src = fetchFromGitHub {
       owner = "BlueManCZ";
       repo = "hyprland-config";
       tag = "v${version}";
-      hash = "sha256-TTh5UnFdRaGvYNlx/qkSWnDEnj101tmi+jDuXU/jCnI=";
+      hash = "sha256-rk2Wu21i+nZuEk1bla22GYcTIrl6MQK6Hp/ZBF3ftpw=";
     };
     build-system = [ python3Packages.hatchling ];
     doCheck = false;


### PR DESCRIPTION
This PR bumps the pinned nix version of hyprland-config to match what's required by pyproject.toml.

We can probably catch this via a linter job if we think the flake will stick around longer... (which it probably will need to :face_exhaling:)