### PR TITLE
ci: fail when nix pins drift from pyproject floors

### DIFF
--- a/NIX.md
+++ b/NIX.md
@@ -17,6 +17,10 @@ addressable for `nix-update` as `hyprmod.<dep>`. Each dep uses
 `buildPythonPackage rec` with `tag = "v${version}"` so `nix-update` rewrites
 both the version string and the hash in one step.
 
+`tests/test_nix_pins.py` fails if a pin here drifts from the matching `>=`
+floor in `pyproject.toml`, so a forgotten bump surfaces in CI instead of at
+build time.
+
 ### Option A — automated (via passthru.updateScript)
 
 ```bash

--- a/tests/test_nix_pins.py
+++ b/tests/test_nix_pins.py
@@ -1,0 +1,30 @@
+"""Verify that the Nix expression pins the dependency versions pyproject requires.
+
+``nix/hyprmod.nix`` pins each ``hyprland-*`` library to an exact version.
+Bumping a floor in ``pyproject.toml`` without rerunning the update script
+(see ``NIX.md``) leaves the flake building against a version older than the
+code needs, and nothing else in CI builds the flake.
+"""
+
+import re
+import tomllib
+from pathlib import Path
+
+ROOT = Path(__file__).parent.parent
+
+NIX_PIN = re.compile(r'pname = "(hyprland-[\w-]+)";\s*version = "([^"]+)";')
+
+
+def _pyproject_floors() -> dict[str, str]:
+    with (ROOT / "pyproject.toml").open("rb") as handle:
+        dependencies = tomllib.load(handle)["project"]["dependencies"]
+    return dict(dep.split(">=") for dep in dependencies if dep.startswith("hyprland-"))
+
+
+def _nix_pins() -> dict[str, str]:
+    return dict(NIX_PIN.findall((ROOT / "nix" / "hyprmod.nix").read_text()))
+
+
+class TestNixPins:
+    def test_pins_match_pyproject_floors(self):
+        assert _nix_pins() == _pyproject_floors()


### PR DESCRIPTION
Follow-up to #75.

`nix/hyprmod.nix` pins each `hyprland-*` library to an exact version, but nothing in CI builds the flake. Bumping a floor in `pyproject.toml` without rerunning the update script goes unnoticed until someone actually builds the package, which is how the `hyprland-config` pin ended up a release behind.

`tests/test_nix_pins.py` compares the five pins against the `>=` floors and fails on a mismatch. It rides the existing test job, needs no Nix on the runner, and runs in ~10ms.

It does not check hashes. Those are written by `nix-update`, so version drift is the failure mode that actually happens.

Rebased onto main now that #75 has landed. Before the rebase the check failed with `hyprland-config 0.9.12 != 0.9.13`, exactly the bug #75 fixed.