### PR TITLE
Bump hyprland-* floors and check the Nix pin hashes

### DIFF
--- a/NIX.md
+++ b/NIX.md
@@ -18,8 +18,11 @@ addressable for `nix-update` as `hyprmod.<dep>`. Each dep uses
 both the version string and the hash in one step.
 
 `tests/test_nix_pins.py` fails if a pin here drifts from the matching `>=`
-floor in `pyproject.toml`, so a forgotten bump surfaces in CI instead of at
-build time.
+floor in `pyproject.toml`, or if a pinned hash does not match the tag it
+claims: it downloads each tag from GitHub and recomputes the NAR hash that
+`fetchFromGitHub` records. Either mistake surfaces in CI instead of at build
+time. The hash checks skip themselves when the downloads fail, so the suite
+still runs offline.
 
 ### Option A — automated (via passthru.updateScript)
 

--- a/hyprmod/core/schema.py
+++ b/hyprmod/core/schema.py
@@ -58,11 +58,8 @@ def _resolve_schema_options(version: str | None) -> Mapping[str, HyprOption]:
     if version is None:
         return hyprland_schema.OPTIONS_BY_KEY
 
-    # hyprland_schema.load() keys versions by the GitHub tag (``vX.Y.Z``),
-    # while HyprlandState.version drops the prefix (``X.Y.Z``). Normalise.
-    tag = version if version.startswith("v") else f"v{version}"
     try:
-        return hyprland_schema.load(tag).options_by_key
+        return hyprland_schema.load(version).options_by_key
     except hyprland_schema.MigrationError as exc:
         log.warning(
             "Could not load schema for Hyprland %s (%s); using bundled %s",

--- a/nix/hyprmod.nix
+++ b/nix/hyprmod.nix
@@ -35,13 +35,13 @@ let
 
   hyprland-config = python3Packages.buildPythonPackage rec {
     pname = "hyprland-config";
-    version = "0.9.13";
+    version = "0.9.14";
     pyproject = true;
     src = fetchFromGitHub {
       owner = "BlueManCZ";
       repo = "hyprland-config";
       tag = "v${version}";
-      hash = "sha256-rk2Wu21i+nZuEk1bla22GYcTIrl6MQK6Hp/ZBF3ftpw=";
+      hash = "sha256-Jgh/X7M+hdp0NPuA0YnfdYU/sxY9hfl/OCihnzobvm8=";
     };
     build-system = [ python3Packages.hatchling ];
     doCheck = false;
@@ -81,13 +81,13 @@ let
 
   hyprland-state = python3Packages.buildPythonPackage rec {
     pname = "hyprland-state";
-    version = "0.4.3";
+    version = "0.4.4";
     pyproject = true;
     src = fetchFromGitHub {
       owner = "BlueManCZ";
       repo = "hyprland-state";
       tag = "v${version}";
-      hash = "sha256-gFmACUjLwkBV0LGdSkoxE8viV1Jr7DDM9obpfPuP+A0=";
+      hash = "sha256-Vb6LIH3DC/6/mbh3Bji/qpil5r0Xp+WiELQ+rL+S6UU=";
     };
     build-system = [ python3Packages.hatchling ];
     dependencies = [ hyprland-config hyprland-monitors hyprland-schema hyprland-socket ];

--- a/nix/hyprmod.nix
+++ b/nix/hyprmod.nix
@@ -50,13 +50,13 @@ let
 
   hyprland-schema = python3Packages.buildPythonPackage rec {
     pname = "hyprland-schema";
-    version = "0.6.3";
+    version = "0.7.1";
     pyproject = true;
     src = fetchFromGitHub {
       owner = "BlueManCZ";
       repo = "hyprland-schema";
       tag = "v${version}";
-      hash = "sha256-yAhzzv08vK19M0ypOH8LvmXUDFE92LoQi3QW134q1Ao=";
+      hash = "sha256-36nSnuiWtJeCGcxJB2hNlbWEd0t2Ke5hhsUJddoap+w=";
     };
     build-system = [ python3Packages.hatchling ];
     doCheck = false;
@@ -81,13 +81,13 @@ let
 
   hyprland-state = python3Packages.buildPythonPackage rec {
     pname = "hyprland-state";
-    version = "0.4.4";
+    version = "0.4.5";
     pyproject = true;
     src = fetchFromGitHub {
       owner = "BlueManCZ";
       repo = "hyprland-state";
       tag = "v${version}";
-      hash = "sha256-Vb6LIH3DC/6/mbh3Bji/qpil5r0Xp+WiELQ+rL+S6UU=";
+      hash = "sha256-nRKZ1ZXueW7Kees0q+evjTaVDUxzYsvUaotyVma8eQc=";
     };
     build-system = [ python3Packages.hatchling ];
     dependencies = [ hyprland-config hyprland-monitors hyprland-schema hyprland-socket ];

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,9 +6,9 @@ license = "GPL-3.0-or-later"
 requires-python = ">=3.12"
 dependencies = [
     "pygobject>=3.56.2",
-    "hyprland-config>=0.9.13",
+    "hyprland-config>=0.9.14",
     "hyprland-schema>=0.6.3",
-    "hyprland-state>=0.4.3",
+    "hyprland-state>=0.4.4",
     "hyprland-monitors>=0.8.0",
     "hyprland-socket>=0.12.2",
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,8 +7,8 @@ requires-python = ">=3.12"
 dependencies = [
     "pygobject>=3.56.2",
     "hyprland-config>=0.9.14",
-    "hyprland-schema>=0.6.3",
-    "hyprland-state>=0.4.4",
+    "hyprland-schema>=0.7.1",
+    "hyprland-state>=0.4.5",
     "hyprland-monitors>=0.8.0",
     "hyprland-socket>=0.12.2",
 ]

--- a/tests/test_nix_pins.py
+++ b/tests/test_nix_pins.py
@@ -1,18 +1,32 @@
 """Verify that the Nix expression pins the dependency versions pyproject requires.
 
-``nix/hyprmod.nix`` pins each ``hyprland-*`` library to an exact version.
-Bumping a floor in ``pyproject.toml`` without rerunning the update script
-(see ``NIX.md``) leaves the flake building against a version older than the
-code needs, and nothing else in CI builds the flake.
+``nix/hyprmod.nix`` pins each ``hyprland-*`` library to an exact version and
+source hash. Bumping a floor in ``pyproject.toml`` without rerunning the update
+script (see ``NIX.md``) leaves the flake building against a version older than
+the code needs, and nothing else in CI builds the flake.
 """
 
+import hashlib
+import io
+import os
 import re
+import stat
+import tarfile
+import tempfile
 import tomllib
+import urllib.error
+import urllib.request
+from base64 import b64encode
 from pathlib import Path
+
+import pytest
 
 ROOT = Path(__file__).parent.parent
 
-NIX_PIN = re.compile(r'pname = "(hyprland-[\w-]+)";\s*version = "([^"]+)";')
+NIX_PIN = re.compile(
+    r'pname = "(hyprland-[\w-]+)";\s*version = "([^"]+)";.*?hash = "([^"]+)";',
+    re.DOTALL,
+)
 
 
 def _pyproject_floors() -> dict[str, str]:
@@ -21,10 +35,91 @@ def _pyproject_floors() -> dict[str, str]:
     return dict(dep.split(">=") for dep in dependencies if dep.startswith("hyprland-"))
 
 
-def _nix_pins() -> dict[str, str]:
-    return dict(NIX_PIN.findall((ROOT / "nix" / "hyprmod.nix").read_text()))
+def _nix_pins() -> dict[str, tuple[str, str]]:
+    text = (ROOT / "nix" / "hyprmod.nix").read_text()
+    return {name: (version, hash_) for name, version, hash_ in NIX_PIN.findall(text)}
+
+
+def _write(nar: bytearray, value: str | bytes) -> None:
+    """Append one NAR token: an 8-byte little-endian length, then padded bytes."""
+    if isinstance(value, str):
+        value = value.encode()
+    nar += len(value).to_bytes(8, "little")
+    nar += value
+    nar += b"\0" * (-len(value) % 8)
+
+
+def _write_node(nar: bytearray, path: Path) -> None:
+    _write(nar, "(")
+    _write(nar, "type")
+    if path.is_symlink():
+        _write(nar, "symlink")
+        _write(nar, "target")
+        _write(nar, os.readlink(path))
+    elif path.is_dir():
+        _write(nar, "directory")
+        for entry in sorted(path.iterdir(), key=lambda p: p.name.encode()):
+            _write(nar, "entry")
+            _write(nar, "(")
+            _write(nar, "name")
+            _write(nar, entry.name)
+            _write(nar, "node")
+            _write_node(nar, entry)
+            _write(nar, ")")
+    else:
+        _write(nar, "regular")
+        if path.stat().st_mode & stat.S_IXUSR:
+            _write(nar, "executable")
+            _write(nar, "")
+        _write(nar, "contents")
+        _write(nar, path.read_bytes())
+    _write(nar, ")")
+
+
+def _nar_hash(root: Path) -> str:
+    """Return the SRI hash Nix would record for *root*, without invoking Nix.
+
+    ``fetchFromGitHub`` hashes the *unpacked* archive, serialised as a NAR:
+    a header token followed by one node per filesystem entry, directories
+    sorted by name. Only the owner-execute bit is captured; the rest of the
+    mode, ownership and timestamps are not part of the archive.
+    """
+    nar = bytearray()
+    _write(nar, "nix-archive-1")
+    _write_node(nar, root)
+    return "sha256-" + b64encode(hashlib.sha256(nar).digest()).decode()
+
+
+def _fetch_nar_hash(repo: str, version: str) -> str:
+    url = f"https://github.com/BlueManCZ/{repo}/archive/v{version}.tar.gz"
+    try:
+        with urllib.request.urlopen(url, timeout=60) as response:
+            archive = response.read()
+    except urllib.error.HTTPError as exc:
+        pytest.fail(f"{url} is not fetchable: {exc}")
+    except OSError as exc:
+        pytest.skip(f"no network access for {url}: {exc}")
+
+    with tempfile.TemporaryDirectory() as workdir:
+        with tarfile.open(fileobj=io.BytesIO(archive)) as tar:
+            tar.extractall(workdir, filter="data")
+        # fetchzip unpacks with stripRoot, so the hash covers the contents of
+        # the archive's single top-level directory rather than the directory.
+        (unpacked,) = Path(workdir).iterdir()
+        return _nar_hash(unpacked)
+
+
+PINS = sorted((name, version, hash_) for name, (version, hash_) in _nix_pins().items())
 
 
 class TestNixPins:
     def test_pins_match_pyproject_floors(self):
-        assert _nix_pins() == _pyproject_floors()
+        pinned_versions = {name: version for name, (version, _) in _nix_pins().items()}
+        assert pinned_versions == _pyproject_floors()
+
+    @pytest.mark.parametrize(("repo", "version", "expected"), PINS, ids=[p[0] for p in PINS])
+    def test_hash_matches_the_pinned_tag(self, repo: str, version: str, expected: str):
+        """``nix-update`` rewrites version and hash together, so the two drift
+        only when a pin is edited by hand. Nothing else notices until someone
+        builds the flake and the fetch aborts on a hash mismatch."""
+        assert _fetch_nar_hash(repo, version) == expected

--- a/uv.lock
+++ b/uv.lock
@@ -13,11 +13,11 @@ wheels = [
 
 [[package]]
 name = "hyprland-config"
-version = "0.9.13"
+version = "0.9.14"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/c5/87/b04a355e41088bf0040500203d99f72105536e7ed1f1bca0d793d472d27e/hyprland_config-0.9.13.tar.gz", hash = "sha256:71346a6b10844736296b6e56de4cb2af892bc87d42b3aadf386ebeedbc036935", size = 103753, upload-time = "2026-07-27T08:00:32.077Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/da/bc/e7a45f9b820fed4099f4d5a0981b815553caa81df7f55cc83dd531ebff2e/hyprland_config-0.9.14.tar.gz", hash = "sha256:02e5e44b047ed34e445b20c067e478117cd44c2277ae9c8d6fbf11cdbe33a614", size = 104951, upload-time = "2026-07-30T06:51:03.43Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/cc/71/514bc9ee7e4306cfb745350f3068578d0d3f78bc1191d870bd7b17309df8/hyprland_config-0.9.13-py3-none-any.whl", hash = "sha256:b2f73ecbb4dd5a4d8b88e8e6aeb970e9c9f1bfce5f604d5ea4385d11c1fcea22", size = 127059, upload-time = "2026-07-27T08:00:30.585Z" },
+    { url = "https://files.pythonhosted.org/packages/4f/bc/2c7f41a6874d27f365040477cb739d7abc0ae83fd246c911bc91cba9b963/hyprland_config-0.9.14-py3-none-any.whl", hash = "sha256:12a84177f4faab80a349a966fd2c90d65c723777cc41af6822721ab80d5760dd", size = 128372, upload-time = "2026-07-30T06:51:01.759Z" },
 ]
 
 [[package]]
@@ -52,7 +52,7 @@ wheels = [
 
 [[package]]
 name = "hyprland-state"
-version = "0.4.3"
+version = "0.4.4"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "hyprland-config" },
@@ -60,9 +60,9 @@ dependencies = [
     { name = "hyprland-schema" },
     { name = "hyprland-socket" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/45/fc/0561fa0fe649cc5f74a21ea70859b6abe887123d06778ddc759fc0be846a/hyprland_state-0.4.3.tar.gz", hash = "sha256:5899008867369aa9f19c25e7a987694535a11c52f48ed56f9e799e1962d7658a", size = 20036, upload-time = "2026-06-24T09:59:06.684Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/0d/a0/a1ab14d4153f3f86d1cb720a43d2563f11cce1989324033528e522f02b7b/hyprland_state-0.4.4.tar.gz", hash = "sha256:7885e210761ac030b1b7937ea4c541839a294714bf75332d75076d3424071ebf", size = 20041, upload-time = "2026-07-30T06:58:16.32Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/09/24/0a51672be6dd4a65b3869003ae76e765988b4653feb386e37d536e6ed90a/hyprland_state-0.4.3-py3-none-any.whl", hash = "sha256:6cac951b4e6982209aee61103d815319e177d6b5dfd9c9b101cb2f6cb757718b", size = 23341, upload-time = "2026-06-24T09:59:05.318Z" },
+    { url = "https://files.pythonhosted.org/packages/e3/e8/a1293e2d786c72ec47f8de58848a0e3f3ea8bb26a3e0f77097d8590a3f51/hyprland_state-0.4.4-py3-none-any.whl", hash = "sha256:631e65cbdcf3498fa9f4476480ca6589e4c818600cc955b677f78887f4b88acf", size = 23340, upload-time = "2026-07-30T06:58:14.767Z" },
 ]
 
 [[package]]
@@ -88,11 +88,11 @@ dev = [
 
 [package.metadata]
 requires-dist = [
-    { name = "hyprland-config", specifier = ">=0.9.13" },
+    { name = "hyprland-config", specifier = ">=0.9.14" },
     { name = "hyprland-monitors", specifier = ">=0.8.0" },
     { name = "hyprland-schema", specifier = ">=0.6.3" },
     { name = "hyprland-socket", specifier = ">=0.12.2" },
-    { name = "hyprland-state", specifier = ">=0.4.3" },
+    { name = "hyprland-state", specifier = ">=0.4.4" },
     { name = "pygobject", specifier = ">=3.56.2" },
 ]
 

--- a/uv.lock
+++ b/uv.lock
@@ -34,11 +34,11 @@ wheels = [
 
 [[package]]
 name = "hyprland-schema"
-version = "0.6.3"
+version = "0.7.1"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/33/99/ae072f40f7b04a4f12973d4b1a4fcb67ba7f7dc644345cee6d7dc09f3bb2/hyprland_schema-0.6.3.tar.gz", hash = "sha256:e5a46fac1aeabbadc0a3c9fcfc1ec4bcea405eec9b670cb3960fbd6420666ad0", size = 46048, upload-time = "2026-06-12T07:06:38.084Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/af/48/11d41c3740072c309fd1eb61dfbfe4f9897a2b1124c1f10cb17a18dc8172/hyprland_schema-0.7.1.tar.gz", hash = "sha256:e73d4a19aece1df602c52b2985df35f6c8bc584b0fa7058ea56e1aab9fc01233", size = 47844, upload-time = "2026-07-31T05:42:32.186Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/34/18/fba6fa5b317464f0c21e6fe459322b8fd9acea5d3ad45878237da82e2bd5/hyprland_schema-0.6.3-py3-none-any.whl", hash = "sha256:957e5ca6d8a0e295e7b40d2e6954926730339fc60de929c2fb69691d06d93b41", size = 50854, upload-time = "2026-06-12T07:06:36.755Z" },
+    { url = "https://files.pythonhosted.org/packages/0f/24/66d5aad64573e38a5ec31820f3a920ff6a79364a329dba7f3e708bced536/hyprland_schema-0.7.1-py3-none-any.whl", hash = "sha256:97637f24ac593232e388f99b079c4166cc8e321775e9097470f3b467cda551dc", size = 53309, upload-time = "2026-07-31T05:42:30.964Z" },
 ]
 
 [[package]]
@@ -52,7 +52,7 @@ wheels = [
 
 [[package]]
 name = "hyprland-state"
-version = "0.4.4"
+version = "0.4.5"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "hyprland-config" },
@@ -60,9 +60,9 @@ dependencies = [
     { name = "hyprland-schema" },
     { name = "hyprland-socket" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/0d/a0/a1ab14d4153f3f86d1cb720a43d2563f11cce1989324033528e522f02b7b/hyprland_state-0.4.4.tar.gz", hash = "sha256:7885e210761ac030b1b7937ea4c541839a294714bf75332d75076d3424071ebf", size = 20041, upload-time = "2026-07-30T06:58:16.32Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/da/52/bc2f3b68e6f912ae71a89bdca7ca5e2ca285658413bf2922c1e12dae94fa/hyprland_state-0.4.5.tar.gz", hash = "sha256:ead2b832b067a56ba99ec3295408062de7c6398303da45242f49a0bcd887c471", size = 20300, upload-time = "2026-07-31T06:02:07.785Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/e3/e8/a1293e2d786c72ec47f8de58848a0e3f3ea8bb26a3e0f77097d8590a3f51/hyprland_state-0.4.4-py3-none-any.whl", hash = "sha256:631e65cbdcf3498fa9f4476480ca6589e4c818600cc955b677f78887f4b88acf", size = 23340, upload-time = "2026-07-30T06:58:14.767Z" },
+    { url = "https://files.pythonhosted.org/packages/44/58/4beea8c5ea95f71dacf205914508b7ed8d432be767f116a616a7eb7ee0b7/hyprland_state-0.4.5-py3-none-any.whl", hash = "sha256:90c42f02b144698fc982b17e9ee4f953b08ca714a0cf88b6d3413e91abfa619e", size = 23620, upload-time = "2026-07-31T06:02:06.421Z" },
 ]
 
 [[package]]
@@ -90,9 +90,9 @@ dev = [
 requires-dist = [
     { name = "hyprland-config", specifier = ">=0.9.14" },
     { name = "hyprland-monitors", specifier = ">=0.8.0" },
-    { name = "hyprland-schema", specifier = ">=0.6.3" },
+    { name = "hyprland-schema", specifier = ">=0.7.1" },
     { name = "hyprland-socket", specifier = ">=0.12.2" },
-    { name = "hyprland-state", specifier = ">=0.4.4" },
+    { name = "hyprland-state", specifier = ">=0.4.5" },
     { name = "pygobject", specifier = ">=3.56.2" },
 ]
 


### PR DESCRIPTION
Floor bump for the four libraries with releases since the last one, plus hash coverage for the Nix pins.

| dep | floor | why |
| --- | --- | --- |
| hyprland-config | 0.9.13 -> 0.9.14 | Lua save fix ([#3](https://github.com/BlueManCZ/hyprland-config/pull/3)). hyprmod never hits it: it writes its managed file through `serialize_any()` and edits Lua entrypoints as text, never round-tripping a user's `.lua` through a `Document`. |
| hyprland-schema | 0.6.3 -> 0.7.1 | `load()` accepts the bare version, and the v0.56 schema is bundled. |
| hyprland-state | 0.4.4 -> 0.4.5 | Requires schema 0.7.1; also stops the validator rejecting both spellings of a choice value. hyprmod applies with `validate=False`, so it never hit that one. |
| hyprland-monitors / hyprland-socket | unchanged | Already at the latest release. |
| pygobject | unchanged | Patch release with nothing we need; no reason to force an upgrade on distro packagers. |

## hyprland-schema 0.7.1

The last revision of this PR held the schema at 0.6.3. `hyprland_schema.load()` matched only its own `vX.Y.Z` keys, so the bare version `hyprctl` reports missed every bundled version, fell through to a GitHub fetch that 404s, and landed on `OPTIONS_BY_KEY`, the bundled latest. Under 0.6.3 that accident happened to yield the right schema; under 0.7.0 every user not on 0.56 would silently have got 0.56's option set and types.

0.7.1 normalises both spellings, so the floor can move. hyprmod worked around the lookup bug by prefixing the version itself before calling `load()`; that workaround is now removed.

## Nix pins

`tests/test_nix_pins.py` already failed when a pin drifted from the matching `>=` floor. It now checks the hashes too: each pinned tag is downloaded from GitHub and its NAR hash recomputed the way `fetchFromGitHub` records it, which is roughly 40 lines of the serialisation from appendix B of the Nix thesis. All five existing pins reproduce byte-for-byte, so the two new ones were computed the same way rather than pasted from a failed build.

A hand-edited pin was previously wrong until someone built the flake, which no CI job does. The hash checks skip themselves when the download fails, so the suite still runs offline.
