### PR TITLE
Require hyprland-monitors 0.9.0 for live monitor resets

### DIFF
--- a/hyprmod/pages/monitors/card.py
+++ b/hyprmod/pages/monitors/card.py
@@ -217,7 +217,7 @@ def _format_hdr_value(
     default so the line gets omitted from the saved config.
 
     The live ``hl.monitor()`` apply emits explicit defaults for the
-    ``auto_default=False`` fields via ``explicit_hdr_defaults=True`` in
+    ``auto_default=False`` fields via ``for_live_apply=True`` in
     hyprland-state, which handles the additive-omission reset there.
     """
     if not auto_default and abs(value - default) < 1e-3:

--- a/nix/hyprmod.nix
+++ b/nix/hyprmod.nix
@@ -65,13 +65,13 @@ let
 
   hyprland-monitors = python3Packages.buildPythonPackage rec {
     pname = "hyprland-monitors";
-    version = "0.8.0";
+    version = "0.9.0";
     pyproject = true;
     src = fetchFromGitHub {
       owner = "BlueManCZ";
       repo = "hyprland-monitors";
       tag = "v${version}";
-      hash = "sha256-a7fEDPPN9XYsrpE99C9c9MZGpqg24ZlY6vvHzgvNtzc=";
+      hash = "sha256-7nrLBsU7QacSf5l0Y/LgegfHtx2qHBNCJUBz0cc3dLE=";
     };
     build-system = [ python3Packages.hatchling ];
     dependencies = [ hyprland-socket ];
@@ -81,13 +81,13 @@ let
 
   hyprland-state = python3Packages.buildPythonPackage rec {
     pname = "hyprland-state";
-    version = "0.4.5";
+    version = "0.4.6";
     pyproject = true;
     src = fetchFromGitHub {
       owner = "BlueManCZ";
       repo = "hyprland-state";
       tag = "v${version}";
-      hash = "sha256-nRKZ1ZXueW7Kees0q+evjTaVDUxzYsvUaotyVma8eQc=";
+      hash = "sha256-IBkD4piipWNci4WR5ZCyPtNCFABqIcT6LhAu3pC96So=";
     };
     build-system = [ python3Packages.hatchling ];
     dependencies = [ hyprland-config hyprland-monitors hyprland-schema hyprland-socket ];

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,8 +12,8 @@ dependencies = [
     "pygobject>=3.56.2",
     "hyprland-config>=0.9.14",
     "hyprland-schema>=0.7.1",
-    "hyprland-state>=0.4.5",
-    "hyprland-monitors>=0.8.0",
+    "hyprland-state>=0.4.6",
+    "hyprland-monitors>=0.9.0",
     "hyprland-socket>=0.12.2",
 ]
 

--- a/tests/test_monitor_card_helpers.py
+++ b/tests/test_monitor_card_helpers.py
@@ -105,8 +105,8 @@ class TestHdrSliderValues:
         # spec.default is a real value to write to disk explicitly (panel EDID
         # for luminance, the HDR-mode 0.5 starting point for sdr_brightness);
         # False means spec.default is Hyprland's own correct no-override, so
-        # omit from disk and let hyprland-state's explicit_hdr_defaults=True
-        # handle the live-apply reset.
+        # omit from disk and let hyprland-state's for_live_apply=True handle
+        # the live-apply reset.
         for field in (
             "sdr_brightness",
             "sdr_min_luminance",

--- a/uv.lock
+++ b/uv.lock
@@ -22,14 +22,14 @@ wheels = [
 
 [[package]]
 name = "hyprland-monitors"
-version = "0.8.0"
+version = "0.9.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "hyprland-socket" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/da/31/78f520fe585edb20e7f4a979f9588b2d5f9250c330915ce9be23ed5cade3/hyprland_monitors-0.8.0.tar.gz", hash = "sha256:fd4b75f9163aa30c2e73d9c49d98f4f159ee1485b45eb2fcf345ac387f9efa46", size = 13026, upload-time = "2026-06-08T19:11:54.493Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/d1/09/d8cff343afb02a76bf8004ca189038d65620f78cedd90cd4aa33d04b448e/hyprland_monitors-0.9.0.tar.gz", hash = "sha256:32afec5fba923283de22239d009772c50e974c0a2b3ab070e9d3ce7e67d7b99a", size = 13450, upload-time = "2026-08-08T06:03:27.478Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/ca/fe/3c032f5e9ac50f447ddc06a4d56b968563c05461c5ae15249a85f77fc5f9/hyprland_monitors-0.8.0-py3-none-any.whl", hash = "sha256:0791a1a3c9259546d55fc4e52e78cf8c38a1fdfcab54050748a120e6202ec71b", size = 14728, upload-time = "2026-06-08T19:11:53.359Z" },
+    { url = "https://files.pythonhosted.org/packages/ea/e5/5515c5d0ef146622250cc9cbdfdf1b603b77087553becb1191501de88d71/hyprland_monitors-0.9.0-py3-none-any.whl", hash = "sha256:0f6eeb3dae2a9db0a5eaaeca09aa63f4ff0d31d6ff7dbe763245b501208f1989", size = 15168, upload-time = "2026-08-08T06:03:26.412Z" },
 ]
 
 [[package]]
@@ -52,7 +52,7 @@ wheels = [
 
 [[package]]
 name = "hyprland-state"
-version = "0.4.5"
+version = "0.4.6"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "hyprland-config" },
@@ -60,9 +60,9 @@ dependencies = [
     { name = "hyprland-schema" },
     { name = "hyprland-socket" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/da/52/bc2f3b68e6f912ae71a89bdca7ca5e2ca285658413bf2922c1e12dae94fa/hyprland_state-0.4.5.tar.gz", hash = "sha256:ead2b832b067a56ba99ec3295408062de7c6398303da45242f49a0bcd887c471", size = 20300, upload-time = "2026-07-31T06:02:07.785Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/16/9e/be2d36f174e63000490b015dba908c05a1c650de0dab0b85ab1caee5a484/hyprland_state-0.4.6.tar.gz", hash = "sha256:09b70849978ec4aa5ba1375639df151639ca7b611a48091894b0560c697b3e39", size = 20326, upload-time = "2026-08-08T06:06:14.064Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/44/58/4beea8c5ea95f71dacf205914508b7ed8d432be767f116a616a7eb7ee0b7/hyprland_state-0.4.5-py3-none-any.whl", hash = "sha256:90c42f02b144698fc982b17e9ee4f953b08ca714a0cf88b6d3413e91abfa619e", size = 23620, upload-time = "2026-07-31T06:02:06.421Z" },
+    { url = "https://files.pythonhosted.org/packages/13/08/f400b0fd1ffff3d6c7b17431a271cdd5c41bb373be61d8cddbb2e5605ea0/hyprland_state-0.4.6-py3-none-any.whl", hash = "sha256:50a869715629cbf35dcc03519ae506a67c248c158c2bb384ded2aab8670e0977", size = 23651, upload-time = "2026-08-08T06:06:12.793Z" },
 ]
 
 [[package]]
@@ -90,10 +90,10 @@ dev = [
 [package.metadata]
 requires-dist = [
     { name = "hyprland-config", specifier = ">=0.9.14" },
-    { name = "hyprland-monitors", specifier = ">=0.8.0" },
+    { name = "hyprland-monitors", specifier = ">=0.9.0" },
     { name = "hyprland-schema", specifier = ">=0.7.1" },
     { name = "hyprland-socket", specifier = ">=0.12.2" },
-    { name = "hyprland-state", specifier = ">=0.4.5" },
+    { name = "hyprland-state", specifier = ">=0.4.6" },
     { name = "pycairo", specifier = ">=1.16" },
     { name = "pygobject", specifier = ">=3.56.2" },
 ]


### PR DESCRIPTION
Fixes #82.

## The bug

In Lua mode the `monitor` keyword is translated to `hl.monitor()`, which seeds the rule from the existing one for that output:

```cpp
CMonitorRuleParser parser(output);
const auto existing = ...find_if(monitorRuleMgr()->all(), name == output);
if (existing != end) parser.rule() = *existing;
```

Any key the config line leaves out therefore keeps its previous value instead of falling back to the default. `lines_from_monitors` omitted `transform` when it was 0, so picking **Normal** after rotating a monitor sent a line with no transform at all, the display stayed rotated, and the deferred resync read the stale value back from IPC and snapped the dropdown to the old angle. Rotating between two non-zero angles always worked, which is why it looked like Normal specifically was broken.

Hyprlang configs are unaffected: the legacy handler builds a fresh rule per line.

Same cause hit `bitdepth` and `cm` when their override was cleared.

## The fix

It lives in the libraries; this PR is the floor and pin bump.

- **hyprland-monitors 0.9.0** renames `lines_from_monitors(explicit_hdr_defaults=...)` to `for_live_apply=...` and emits `transform, 0`, `bitdepth, 8` and `cm, srgb` under it. The flag already existed for exactly this reason (SDR brightness and saturation) but its name scoped it to HDR, so nothing else was wired up.
- **hyprland-state 0.4.6** passes the flag from `monitors.apply()`.

Saved configs are unchanged and stay free of redundant defaults, since a reload clears all monitor rules first.

## Verification

Reproduced and confirmed fixed against Hyprland 0.56.1 on a throwaway headless output, driving the real `eval_lua(keyword_to_lua(...))` path rather than a mock:

```
set bitdepth=10   -> bitdepth=10    omit -> bitdepth=10  (sticks)   bitdepth=8 -> 8
set cm=wide       -> cm='wide'      omit -> cm='wide'    (sticks)   cm=srgb    -> srgb
set transform=3   -> transform=3    omit -> transform=3  (sticks)   transform,0 -> 0
```

Combined, with the line the new emitter produces:

```
all three overridden   transform=3 format=XBGR2101010 cm='wide'
all three cleared      transform=0 format=XRGB8888    cm='srgb'
sent: HEADLESS-3, 1920x1080@60.00Hz, 4520x0, 2, transform, 0, bitdepth, 8, cm, srgb
```

## Known gaps

`mirror_of` has the same bug. It clears with an empty value, which a comma-joined line cannot carry unambiguously, so it needs a format decision rather than a table entry. While testing it I also found that IPC reports `mirrorOf` as the monitor's numeric id rather than its name, which `from_ipc` stores verbatim; worth fixing together in a follow-up.

`vrr` still needs the upstream `-1` sentinel before "use global" can be cleared live.

Separately, `from_ipc` treats `colorManagementPreset == "default"` as "no override", but Hyprland serialises `NCMType::toString(m_cmType)`, whose default is `srgb`. That branch is dead as written; impact is contained because `_clear_unmanaged_extras` clears extras for monitors hyprmod owns.
